### PR TITLE
Update README and docstrings, fix some incosistencies with distances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/cc709npw3lp76yc8?svg=true)](https://ci.appveyor.com/project/mtsch/ripserer-jl)
 
 A Julia reimplementation of [ripser](https://github.com/Ripser/ripser). Work in progress.
+The code works and the performance is not bad but the interfaces and file structure may
+change at any time.
 
 ## TODO
 
-* representative cocycles
-* sparse filtration
+* Representative (co)cycles.
+* Optimize sparse filtrations.

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -187,12 +187,8 @@ function diam(flt::AbstractFiltration{M, T}, vertices) where {M, T}
     n = length(vertices)
     res = typemin(T)
     for i in 1:n, j in i+1:n
-        d = dist(flt, vertices[j], vertices[i])
-        if d == 0
-            return typemax(T)
-        else
-            res = max(res, d)
-        end
+        res = max(res, dist(flt, vertices[j], vertices[i]))
+        res > threshold(flt) && return typemax(T)
     end
     res
 end
@@ -206,7 +202,7 @@ function max_dist(flt::AbstractFiltration{M, T}, us, v::Integer) where {M, T}
     res = typemin(T)
     for u in us
         res = max(res, dist(flt, u, v))
-        res == typemax(T) && break
+        res > threshold(flt) && return typemax(T)
     end
     res
 end

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -266,7 +266,7 @@ represented by `flt`.
 # Settings
 
 `dim_max`: compute persistent homology up to this dimension.
-`modulus`: compute persistent homology with coefficients in the prime field of inether
+`modulus`: compute persistent homology with coefficients in the prime field of inetgers
            mod `modulus`.
 `threshold`: compute persistent homology up to diameter smaller than threshold.
 """

--- a/src/rips.jl
+++ b/src/rips.jl
@@ -163,11 +163,14 @@ default_threshold(dists) =
     RipsFiltration{M, T, A<:AbstractArray{T}}
 
 This type holds the information about the input values.
+The distance matrix has to be a dense matrix.
 
 # Constructor
 
-    RipsFiltration{M}(distance_matrix, dim_max, [threshold=typemax(T)])
-
+    RipsFiltration(distance_matrix;
+                   dim_max=1,
+                   modulus=2,
+                   threshold = default_threshold(dist))
 """
 struct RipsFiltration{M, T, A<:AbstractArray{T}}<:
     AbstractFiltration{M, T, Simplex{M, T}}
@@ -218,11 +221,15 @@ threshold(rips::RipsFiltration) =
     SparseRipsFiltration{M, T, A<:AbstractArray{T}}
 
 This type holds the information about the input values.
+The distance matrix will be converted to a sparse matrix with all values greater than
+threshold deleted. Off-diagonal zeros in the matrix are treaded as `typemax(T)`.
 
 # Constructor
 
-    SparseRipsFiltration{M}(distance_matrix, dim_max, [threshold=typemax(T)])
-
+    SparseRipsFiltration(distance_matrix;
+                         dim_max=1,
+                         modulus=2,
+                         threshold = default_threshold(dist))
 """
 struct SparseRipsFiltration{M, T, A<:AbstractSparseArray{T}}<:
     AbstractFiltration{M, T, Simplex{M, T}}
@@ -257,8 +264,12 @@ Base.length(rips::SparseRipsFiltration) =
     size(rips.dist, 1)
 
 function dist(rips::SparseRipsFiltration{M, T}, i::Integer, j::Integer) where {M, T}
-    res = rips.dist[i, j]
-    iszero(res) ? typemax(T) : res
+    if i == j
+        zero(T)
+    else
+        res = rips.dist[i, j]
+        iszero(res) ? typemax(T) : res
+    end
 end
 
 Base.binomial(rips::SparseRipsFiltration, n, k) =

--- a/test/rips.jl
+++ b/test/rips.jl
@@ -137,7 +137,7 @@ using Ripserer:
                                   2 3 0 4;
                                   9 9 4 0], modulus=3)
                 @test length(flt) == 4
-                @test dist(flt, 3, 3) == (issparse(Filtration) ? typemax(Int) : 0)
+                @test dist(flt, 3, 3) == 0
                 @test dist(flt, 1, 2) == 1
                 @test dist(flt, 1, 3) == 2
                 @test dist(flt, 3, 2) == 3
@@ -147,7 +147,7 @@ using Ripserer:
                                   1 0 3;
                                   2 3 0], threshold=2)
                 @test length(flt) == 3
-                @test dist(flt, 3, 3) == (issparse(Filtration) ? typemax(Int) : 0)
+                @test dist(flt, 3, 3) == 0
                 @test dist(flt, 1, 2) == 1
                 @test dist(flt, 1, 3) == 2
                 @test dist(flt, 3, 2) == (issparse(Filtration) ? typemax(Int) : 3)


### PR DESCRIPTION
* `dist[i, i]` now returns `0` in sparse filtrations.
* `max_dist` and `diam` now return infinity if the value is greater than `threshold`.
* Update `README` and docstrings.