### PR TITLE
Better column assembly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -1,6 +1,7 @@
 module Ripserer
 
 using Compat
+using Future: copy!
 using LinearAlgebra
 using SparseArrays
 

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -128,9 +128,10 @@ Base.eltype(::Type{CoboundaryIterator{<:Any, S}}) where S =
 Return an iterator that iterates over all cofaces of `simplex` of dimension `dim + 1` in
 decreasing order by index.
 """
-coboundary(flt::AbstractFiltration, simplex::AbstractSimplex, dim, all_cofaces=true) =
-    CoboundaryIterator{all_cofaces, disttype(flt),
-                       typeof(simplex), typeof(flt)}(flt, simplex, dim)
+coboundary(flt::AbstractFiltration, simplex::AbstractSimplex, dim, ::Val{false}) =
+    CoboundaryIterator{false, disttype(flt), typeof(simplex), typeof(flt)}(flt, simplex, dim)
+coboundary(flt::AbstractFiltration, simplex::AbstractSimplex, dim) =
+    CoboundaryIterator{true, disttype(flt), typeof(simplex), typeof(flt)}(flt, simplex, dim)
 
 function Base.iterate(ci::CoboundaryIterator{all_cofaces},
                       st = (length(ci.filtration), ci.dim + 1,

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -243,8 +243,12 @@ function assemble_columns!(rm::ReductionMatrix{T}, columns) where T
     n_simplices = binomial(rm.filtration, length(rm.filtration), rm.dim + 2)
     S = eltype(rm.filtration)
 
+    simplices = trues(n_simplices)
+    for k in keys(rm.column_index)
+        @inbounds simplices[k] = false
+    end
     for idx in 1:n_simplices
-        if !haskey(rm.column_index, idx)
+        if simplices[idx]
             sx = S(diam(rm.filtration, vertices(rm.filtration, idx, rm.dim + 1)), idx, 1)
             if diam(sx) ≤ threshold(rm.filtration)
                 push!(columns, sx)

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -247,6 +247,7 @@ function assemble_columns!(rm::ReductionMatrix{T}, columns) where T
     for k in keys(rm.column_index)
         @inbounds simplices[k] = false
     end
+    sizehint!(columns, sum(simplices))
     for idx in 1:n_simplices
         if simplices[idx]
             sx = S(diam(rm.filtration, vertices(rm.filtration, idx, rm.dim + 1)), idx, 1)

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -273,7 +273,7 @@ function assemble_columns!(rm::ReductionMatrix{T}, columns, simplices) where T
     new_simplices = eltype(simplices)[]
 
     for simplex in simplices
-        for coface in coboundary(rm.filtration, simplex, rm.dim, false)
+        for coface in coboundary(rm.filtration, simplex, rm.dim, Val(false))
             if diam(coface) ≤ threshold(rm.filtration)
                 push!(new_simplices, coface)
                 if !haskey(rm.column_index, index(coface))

--- a/src/rips.jl
+++ b/src/rips.jl
@@ -214,5 +214,5 @@ dim_max(rips::SparseRipsFiltration) =
 threshold(rips::SparseRipsFiltration) =
     rips.threshold
 
-SparseArrays.issparse(::Type{SparseRipsFiltration}) =
+SparseArrays.issparse(::Type{<:SparseRipsFiltration}) =
     true

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -87,7 +87,7 @@ using Ripserer:
                     2 3 0]
             flt = RipsFiltration(dist, dim_max=0, threshold=3)
             critical_edges = Simplex{2, Int}[]
-            res = compute_0_dim_pairs!(flt, critical_edges)
+            res, _ = compute_0_dim_pairs!(flt, critical_edges)
 
             @test res == [(0, 1),
                           (0, 2),
@@ -225,7 +225,7 @@ using Ripserer:
                 dists = sparse(torus(16))
                 SparseArrays.fkeep!(dists, (_, _, v) -> v ≤ 1)
 
-                d0, d1, d2 = ripserer(torus(16), dim_max=2)
+                d0, d1, d2 = ripserer(dists, dim_max=2)
 
                 @test length(d0) == 16
 
@@ -239,10 +239,8 @@ using Ripserer:
                 dists = sparse(projective_plane)
                 SparseArrays.fkeep!(dists, (_, _, v) -> v ≤ 2)
 
-                _, d1_2, d2_2 = ripserer(projective_plane,
-                                         dim_max=2, threshold=1)
-                _, d1_3, d2_3 = ripserer(projective_plane,
-                                         dim_max=2, modulus=3, threshold=1)
+                _, d1_2, d2_2 = ripserer(dists, dim_max=2, threshold=1)
+                _, d1_3, d2_3 = ripserer(dists, dim_max=2, modulus=3, threshold=1)
                 @test d1_2 == [(1, typemax(Int))]
                 @test d2_2 == [(1, typemax(Int))]
                 @test isempty(d1_3)


### PR DESCRIPTION
Use different algorithms depending on whether the filtration is sparse or not. For sparse filtrations, simplices are enumerated explicitly via `coboundary`, which is how Ripser does it. This fixes abysmal performance with very sparse filtrations and high dimensions.