### PR TITLE
0-dimensional Representatives

### DIFF
--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -23,7 +23,7 @@ export Infinity, ∞,
     Simplex, coef, set_coef, index, diam, coface_type, vertices, coboundary, dim,
     AbstractFlagFiltration, RipsFiltration, SparseRipsFiltration,
     n_vertices, threshold, edges, edge_type,
-    PersistenceInterval, birth, death, persistence, cocycle, PersistenceDiagram,
+    PersistenceInterval, birth, death, persistence, representative, PersistenceDiagram,
     barcode, barcode!,
     ripserer
 

--- a/src/diagrams.jl
+++ b/src/diagrams.jl
@@ -3,17 +3,17 @@
     PersistenceInterval{T, C}
 
 The type that represents a persistence interval. It behaves exactly like a
-`Tuple{T, Union{T, Infinity}}`, but may have a cocycle attached to it.
+`Tuple{T, Union{T, Infinity}}`, but may have a representative cocycle attached to it.
 """
-struct PersistenceInterval{T, C}
-    birth   ::T
-    death   ::Union{T, Infinity}
-    cocycle ::C
+struct PersistenceInterval{T, R}
+    birth          ::T
+    death          ::Union{T, Infinity}
+    representative ::R
 
     PersistenceInterval(birth::T, death::Union{T, Infinity}) where T =
         new{T, Nothing}(birth, death, nothing)
-    PersistenceInterval(birth::T, death::Union{T, Infinity}, cocycle::C) where {T, C} =
-        new{T, C}(birth, death, cocycle)
+    PersistenceInterval(birth::T, death::Union{T, Infinity}, rep::R) where {T, R} =
+        new{T, R}(birth, death, rep)
 end
 
 PersistenceInterval(t::Tuple{<:Any, <:Any}) =
@@ -23,9 +23,9 @@ Base.show(io::IO, int::PersistenceInterval) =
     print(io, "[", int.birth, ", ", int.death, ")")
 function Base.show(io::IO, ::MIME"text/plain", int::PersistenceInterval{T}) where T
     print(io, "PersistenceInterval{", T, "}", (int.birth, int.death))
-    if !isnothing(int.cocycle)
-        println(io, " with cocycle:")
-        show(io, MIME"text/plain"(), int.cocycle)
+    if !isnothing(int.representative)
+        println(io, " with representative:")
+        show(io, MIME"text/plain"(), int.representative)
     end
 end
 
@@ -62,12 +62,13 @@ Base.isfinite(int::PersistenceInterval) =
     isfinite(death(int))
 
 """
-    cocycle(interval::PersistenceInterval)
+    representative(interval::PersistenceInterval)
 
-Get the cocycle attached to `interval`. If cocycles were not computed, return `nothing`.
+Get the representative cocycle attached to `interval`. If representatives were not computed,
+return `nothing`.
 """
-cocycle(int::PersistenceInterval) =
-    int.cocycle
+representative(int::PersistenceInterval) =
+    int.representative
 
 function Base.iterate(int::PersistenceInterval, i=1)
     if i == 1

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -75,7 +75,7 @@ dim(sx::AbstractSimplex) =
 
 # filtrations ============================================================================ #
 """
-    AbstractFiltration{T, S<:AbstractSimplex{C, T}}
+    AbstractFiltration{T, V<:AbstractSimplex{0, C, T}}
 
 A filtration is used to find the edges in filtration and to determine diameters of
 simplices.
@@ -93,14 +93,16 @@ simplices.
   defaults to `false`.
 * [`birth(::AbstractFiltration, v)`] - optional, defaults to returning `zero(T)`.
 """
-abstract type AbstractFiltration{T, S<:AbstractSimplex{1, <:Any, T}} end
+abstract type AbstractFiltration{T, V<:AbstractSimplex{0, <:Any, T}} end
 
 function Base.show(io::IO, flt::AbstractFiltration)
     print(io, typeof(flt), "(n_vertices=$(n_vertices(flt)))")
 end
 
-edge_type(::AbstractFiltration{<:Any, S}) where S =
-    S
+vertex_type(::AbstractFiltration{<:Any, V}) where V =
+    V
+edge_type(::AbstractFiltration{<:Any, V}) where V =
+    coface_type(V)
 dist_type(::AbstractFiltration{T}) where T =
     T
 

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -343,8 +343,8 @@ reduced. Record it in the reduction matrix and return the persistence interval.
 function reduce_working_column!(
     rs::ReductionState,
     column_simplex::AbstractSimplex,
-    ::Val{cocycles},
-) where cocycles
+    ::Val{representatives},
+) where representatives
     current_pivot = initialize!(rs, column_simplex)
 
     while !isnothing(current_pivot) && has_column(rs.reduction_matrix, index(current_pivot))
@@ -359,9 +359,9 @@ function reduce_working_column!(
         death = diam(current_pivot)
     end
     birth = diam(column_simplex)
-    if cocycles
-        cocycle = collect(rs.reduction_matrix[index(current_pivot)])
-        PersistenceInterval(birth, death, cocycle)
+    if representatives
+        representative = collect(rs.reduction_matrix[index(current_pivot)])
+        PersistenceInterval(birth, death, representative)
     else
         PersistenceInterval(birth, death)
     end
@@ -373,17 +373,17 @@ end
 Compute persistence intervals by reducing `columns`, a collection of simplices.
 """
 function compute_intervals!(
-    rs::ReductionState, columns, ratio, ::Val{cocycles},
-) where cocycles
+    rs::ReductionState, columns, ratio, ::Val{representatives},
+) where representatives
     T = dist_type(rs.filtration)
-    if cocycles
+    if representatives
         C = eltype(columns)
         intervals = PersistenceInterval{T, Vector{C}}[]
     else
         intervals = PersistenceInterval{T, Nothing}[]
     end
     for column in columns
-        interval = reduce_working_column!(rs, column, Val(cocycles))
+        interval = reduce_working_column!(rs, column, Val(representatives))
         if death(interval) > birth(interval) * ratio
             push!(intervals, interval)
         end
@@ -420,11 +420,11 @@ Compute 0-dimensional persistent homology using Kruskal's Algorithm.
 If `filtration` is sparse, also return a vector of all 1-simplices with diameter below
 threshold.
 """
-function zeroth_intervals(filtration, ratio, ::Val{cocycles}) where cocycles
+function zeroth_intervals(filtration, ratio, ::Val{representatives}) where representatives
     T = dist_type(filtration)
     V = vertex_type(filtration)
     dset = DisjointSetsWithBirth([birth(filtration, v) for v in 1:n_vertices(filtration)])
-    if cocycles
+    if representatives
         intervals = PersistenceInterval{T, Vector{V}}[]
     else
         intervals = PersistenceInterval{T, Nothing}[]
@@ -440,13 +440,13 @@ function zeroth_intervals(filtration, ratio, ::Val{cocycles}) where cocycles
         if i ≠ j
             # According to the elder rule, the vertex with the lower birth will fall
             # into a later interval.
-            if cocycles
-                cocycle = map(x -> V(birth(dset, x), x, 1), find_leaves!(dset, i))
+            if representatives
+                representative = map(x -> V(birth(dset, x), x, 1), find_leaves!(dset, i))
             else
-                cocycle = nothing
+                representative = nothing
             end
             interval = PersistenceInterval(
-                max(birth(dset, i), birth(dset, j)), diam(sx), cocycle,
+                max(birth(dset, i), birth(dset, j)), diam(sx), representative,
             )
             if death(interval) > birth(interval) * ratio
                 push!(intervals, interval)
@@ -459,12 +459,12 @@ function zeroth_intervals(filtration, ratio, ::Val{cocycles}) where cocycles
     for v in 1:n_vertices(filtration)
         # ripser does this part wrong -- it just sticks all vertices in here.
         if find_root!(dset, v) == v
-            if cocycles
-                cocycle = map(x -> V(birth(dset, x), x, 1), find_leaves!(dset, v))
+            if representatives
+                representative = map(x -> V(birth(dset, x), x, 1), find_leaves!(dset, v))
             else
-                cocycle = nothing
+                representative = nothing
             end
-            push!(intervals, PersistenceInterval(birth(dset, v), ∞, cocycle))
+            push!(intervals, PersistenceInterval(birth(dset, v), ∞, representative))
         end
     end
     reverse!(columns)
@@ -478,12 +478,12 @@ Compute the ``n``-th intervals of persistent cohomology. The ``n`` is determined
 `eltype` of `columns`. If `next` is `true`, assemble columns for the next dimension.
 """
 function nth_intervals(
-    filtration, columns::Vector{S}, simplices, ratio, ::Val{cocycles}; next=true,
-) where {S<:AbstractSimplex, cocycles}
+    filtration, columns::Vector{S}, simplices, ratio, ::Val{representatives}; next=true,
+) where {S<:AbstractSimplex, representatives}
 
     rs = ReductionState(filtration, S)
     sizehint!(rs.reduction_matrix, length(columns))
-    intervals = compute_intervals!(rs, columns, ratio, Val(cocycles))
+    intervals = compute_intervals!(rs, columns, ratio, Val(representatives))
     if next
         (intervals, assemble_columns!(rs, simplices)...)
     else
@@ -508,7 +508,7 @@ Compute the persistent homology of metric space represented by `dists` or `point
 * `sparse`: if `true`, use `SparseRipsFiltration`. Defaults to `false || issparse(dists)`.
 * `ratio`: only keep intervals with `death(interval) > birth(interval) * ratio`.
   Defaults to `1`.
-* `cocycles`: if `true`, return representative cocycles along with persistence
+* `representatives`: if `true`, return representative cocycles along with persistence
   intervals. Defaults to `false`.
 * `metric`: when calculating persistent homology from points, any metric from
   [`Distances.jl`](https://github.com/JuliaStats/Distances.jl) can be used. Defaults to
@@ -521,7 +521,7 @@ function ripserer(
     dim_max=1,
     sparse=false || issparse(dists),
     ratio=1,
-    cocycles=false,
+    representatives=false,
     kwargs...
 )
     if sparse
@@ -529,7 +529,7 @@ function ripserer(
     else
         filtration = RipsFiltration(dists; kwargs...)
     end
-    ripserer(filtration; dim_max=dim_max, cocycles=cocycles, ratio=ratio)
+    ripserer(filtration; dim_max=dim_max, representatives=representatives, ratio=ratio)
 end
 
 function ripserer(points; metric=Euclidean(), births=nothing, kwargs...)
@@ -542,8 +542,8 @@ end
 
 Compute persistent homology from `filtration` object.
 """
-ripserer(filtration::AbstractFiltration; dim_max=1, cocycles=false, ratio=1) =
-    ripserer(filtration, ratio, Val(dim_max), Val(cocycles))
+ripserer(filtration::AbstractFiltration; dim_max=1, representatives=false, ratio=1) =
+    ripserer(filtration, ratio, Val(dim_max), Val(representatives))
 
 function ripserer(filtration::AbstractFiltration, ratio, ::Val{0}, ::Val{C}) where C
     diagram, _, _ = zeroth_intervals(filtration, ratio, Val(C))

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -346,7 +346,7 @@ struct Simplex{D, M, T, U<:Unsigned} <: AbstractSimplex{D, PrimeField{M}, T}
         diam::T, index::I, coef::Integer
     ) where {D, M, T, I<:Integer, U}
         is_prime(M) || throw(DomainError(M, "modulus must be a prime number"))
-        D > 0 || throw(DomainError(D, "dimension must be a positive integer"))
+        D ≥ 0 || throw(DomainError(D, "dimension must be a non-negative integer"))
         U === unsigned(I) || throw(DomainError(U, "type parameters must match"))
         bits = n_bits(M)
         new{D, M, T, unsigned(I)}(diam, unsigned(index) << bits + mod_prime(coef, Val(M)))
@@ -355,7 +355,7 @@ struct Simplex{D, M, T, U<:Unsigned} <: AbstractSimplex{D, PrimeField{M}, T}
     function Simplex{D, M, T, U}(
         diam::T, index::I, coef::PrimeField{M}
     ) where {D, M, T, I<:Integer, U}
-        D > 0 || throw(DomainError(D, "dimension must be a positive integer"))
+        D ≥ 0 || throw(DomainError(D, "dimension must be a non-negative integer"))
         U === unsigned(I) || throw(DomainError(U, "type parameters must match"))
         bits = n_bits(M)
         new{D, M, T, unsigned(I)}(diam, unsigned(index) << bits + I(coef))

--- a/test/diagrams.jl
+++ b/test/diagrams.jl
@@ -6,7 +6,7 @@ RecipesBase.is_key_supported(::Symbol) = true
 
 @testset "diagrams" begin
     @testset "PersistenceInterval" begin
-        @testset "no cocycle" begin
+        @testset "no representative" begin
             int1 = PersistenceInterval(1, 2)
             @test eltype(int1) == Union{Int, Infinity}
             b, d = int1
@@ -29,7 +29,7 @@ RecipesBase.is_key_supported(::Symbol) = true
             @test int1 < int2
             @test int1 < PersistenceInterval(2, 2)
 
-            @test isnothing(cocycle(int1))
+            @test isnothing(representative(int1))
 
             @test sprint(print, int1) == "[1, 2)"
             @test sprint(print, int2) == "[1, ∞)"
@@ -37,7 +37,7 @@ RecipesBase.is_key_supported(::Symbol) = true
                 "PersistenceInterval{Int64}(1, 2)"
         end
 
-        @testset "with cocycle" begin
+        @testset "with representative" begin
             int1 = PersistenceInterval(2.0, 3.0, [1, 2, 3, 4])
             @test eltype(int1) == Union{Float64, Infinity}
             b, d = int1
@@ -60,14 +60,14 @@ RecipesBase.is_key_supported(::Symbol) = true
             @test int1 > int2
             @test int1 > PersistenceInterval(2.0, 2.0, [1, 2])
 
-            @test cocycle(int1) == [1, 2, 3, 4]
-            @test cocycle(int2) == [1, 2]
+            @test representative(int1) == [1, 2, 3, 4]
+            @test representative(int2) == [1, 2]
 
             @test sprint(print, int1) == "[2.0, 3.0)"
             @test sprint(print, int2) == "[1.0, ∞)"
             @test sprint((io, val) -> show(io, MIME"text/plain"(), val), int1) ==
                 """
-                PersistenceInterval{Float64}(2.0, 3.0) with cocycle:
+                PersistenceInterval{Float64}(2.0, 3.0) with representative:
                 4-element Array{Int64,1}:
                  1
                  2

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -90,7 +90,7 @@ using Ripserer:
                     1 0 3;
                     2 3 0]
             flt = RipsFiltration(dist, threshold=3)
-            res, columns, simplices = zeroth_intervals(flt)
+            res, columns, simplices = zeroth_intervals(flt, 1, Val(false))
 
             @test !isnothing(simplices)
             @test res == PersistenceDiagram(0, [(0, 1),
@@ -103,7 +103,7 @@ using Ripserer:
                     1 0 0;
                     2 0 0]
             flt = SparseRipsFiltration(dist)
-            res, columns, simplices = zeroth_intervals(flt)
+            res, columns, simplices = zeroth_intervals(flt, 1, Val(false))
 
             @test simplices == [Simplex{1, 2}(1, 1, 1),
                                 Simplex{1, 2}(2, 2, 1)]
@@ -118,7 +118,7 @@ using Ripserer:
                            20 30  3 60;
                            40 50 60  4]
             flt = RipsFiltration(dist)
-            res, columns, simplices = zeroth_intervals(flt)
+            res, columns, simplices = zeroth_intervals(flt, 1, Val(false))
             @test res == PersistenceDiagram(0, [(1.0, ∞),
                                                 (2.0, 10.0),
                                                 (3.0, 20.0),

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -283,10 +283,10 @@ using Ripserer:
             end
         end
 
-        @testset "cocycles" begin
-            _, d1, d2 = ripserer(projective_plane, dim_max=2, cocycles=true)
+        @testset "representatives" begin
+            _, d1, d2 = ripserer(projective_plane, dim_max=2, representatives=true)
 
-            @test cocycle(only(d1)) == [
+            @test representative(only(d1)) == [
                 Simplex{1, 2}(1, (11, 10), 1),
                 Simplex{1, 2}(1, (10, 7), 1),
                 Simplex{1, 2}(1, (10, 6), 1),
@@ -297,7 +297,7 @@ using Ripserer:
                 Simplex{1, 2}(1, (5, 1), 1),
                 Simplex{1, 2}(1, (2, 1), 1),
             ]
-            @test cocycle(only(d2)) == [Simplex{2, 2}(1, (6, 2, 1), 1)]
+            @test representative(only(d2)) == [Simplex{2, 2}(1, (6, 2, 1), 1)]
         end
 
         @testset "lower star" begin

--- a/test/rips.jl
+++ b/test/rips.jl
@@ -1,4 +1,4 @@
-using Ripserer: dist_type, dist
+using Ripserer: dist_type, vertex_type, dist
 
 """
     filtration_interface_testset(Filtration, datasets)
@@ -12,18 +12,21 @@ function test_filtration_interface(Filtration, datasets)
             flt = Filtration(data)
 
             T = dist_type(flt)
-            S = edge_type(flt)
+            V = vertex_type(flt)
+            E = edge_type(flt)
 
-            @test S <: AbstractSimplex
-            @test S isa DataType
+            @test V <: AbstractSimplex{0}
+            @test V isa DataType
+            @test E <: AbstractSimplex{1}
+            @test E isa DataType
 
             @test n_vertices(flt) == size(data, 1)
             sx = first(edges(flt))
-            @test sx isa S
+            @test sx isa E
             @test diam(sx) isa T
 
             @test diam(flt, [3, 2, 1]) isa T
-            @test diam(flt, S(one(T), 1, 1), [3, 2], 1) isa T
+            @test diam(flt, E(one(T), 1, 1), [3, 2], 1) isa T
             @test issparse(flt) isa Bool
             @test issparse(Filtration) isa Bool
             @test issparse(Filtration) == issparse(flt)
@@ -48,16 +51,17 @@ end
                 @test dist(flt, 3, 2) == 3
                 @test diam(flt, Simplex{1, 3}(3, 3, 1), [3, 2], 1) == 3
                 @test threshold(flt) == (issparse(Filtration) ? ∞ : 4)
+                @test vertex_type(flt) === Simplex{0, 3, Int, UInt}
                 @test edge_type(flt) === Simplex{1, 3, Int, UInt}
                 @test birth(flt, 1) == 0
                 @test birth(flt, 4) == 0
             end
-            @testset "threshold, edge_type" begin
+            @testset "threshold, vertex_type" begin
                 flt = Filtration([1 1 2;
                                   1 2 3;
                                   2 3 3];
                                  threshold=2,
-                                 edge_type=Simplex{1, 5, Int, UInt})
+                                 vertex_type=Simplex{0, 5, Int, UInt})
 
                 @test n_vertices(flt) == 3
                 @test dist(flt, 3, 3) == 0
@@ -66,6 +70,7 @@ end
                 @test dist(flt, 3, 2) == (issparse(Filtration) ? ∞ : 3)
                 @test diam(flt, Simplex{2, 5}(1, 1, 1), [1, 2], 3) == ∞
                 @test threshold(flt) == (issparse(Filtration) ? ∞ : 2)
+                @test vertex_type(flt) === Simplex{0, 5, Int, UInt}
                 @test edge_type(flt) === Simplex{1, 5, Int, UInt}
 
                 @test birth(flt, 1) == 1
@@ -79,9 +84,9 @@ end
                 dists = [0 1 2; 1 0 3; 2 3 0]
                 @test_throws ArgumentError Filtration(dists, modulus=4)
                 @test_throws ArgumentError Filtration(dists, modulus=-2)
-                @test_throws ArgumentError Filtration(dists, edge_type=Int)
-                @test_throws ArgumentError Filtration(dists, edge_type=Simplex{2,2,Int,UInt})
-                @test_throws TypeError Filtration(dists, edge_type=Simplex{1, 2, Int})
+                @test_throws ArgumentError Filtration(dists, vertex_type=Int)
+                @test_throws ArgumentError Filtration(dists, vertex_type=Simplex{1,2,Int,UInt})
+                @test_throws TypeError Filtration(dists, vertex_type=Simplex{0, 2, Int})
             end
         end
     end

--- a/test/simplex.jl
+++ b/test/simplex.jl
@@ -1,12 +1,12 @@
 using Ripserer: PrimeField, is_prime, n_bits, small_binomial
 
-struct FakeFiltration <: AbstractFiltration{Int, Simplex{1,2,Int,UInt}} end
+struct FakeFiltration <: AbstractFiltration{Int, Simplex{0,2,Int,UInt}} end
 Ripserer.diam(::FakeFiltration, args...) =
     1
 Ripserer.n_vertices(::FakeFiltration) =
     20
 
-struct FakeFiltrationWithThreshold <: AbstractFiltration{Int, Simplex{1,2,Int,UInt}} end
+struct FakeFiltrationWithThreshold <: AbstractFiltration{Int, Simplex{0,2,Int,UInt}} end
 Ripserer.diam(::FakeFiltrationWithThreshold, _, _, v) =
     v ≤ 10 ? 1 : ∞
 Ripserer.n_vertices(::FakeFiltrationWithThreshold) =


### PR DESCRIPTION
* Filtrations now have `vertex_type`.
* Simplices can be 0-dimensional.