### PR TITLE
Code Simplification and Performance Tweaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -28,9 +28,11 @@ struct ReductionState{
         SE = chain_element_type(S, Field)
         C = coface_type(S)
         CE = chain_element_type(C, Field)
+        working_column = Column{CE}()
+        reduction_entries = Column{SE}()
 
         new{Field, S, SE, C, CE, F}(
-            filtration, ReductionMatrix{C, SE}(), Column{CE}(), Column{SE}(),
+            filtration, ReductionMatrix{C, SE}(), working_column, reduction_entries
         )
     end
 end
@@ -150,8 +152,8 @@ function assemble_columns!(
     new_unreduced = C[]
     new_reduced = C[]
 
-    for arr in (unreduced_columns, reduced_columns)
-        for simplex in arr
+    for cols in (unreduced_columns, reduced_columns)
+        for simplex in cols
             for coface in coboundary(rs.filtration, simplex, Val(false))
                 if !has_column(rs.reduction_matrix, coface)
                     push!(new_unreduced, abs(coface))

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -160,6 +160,16 @@ function assemble_columns!(rs::ReductionState{<:Any, S}, simplices) where S
     columns, new_simplices
 end
 
+function zeroth_representative(dset, vertex, reps, CE, V)
+    if reps
+        map(find_leaves!(dset, vertex)) do w
+            CE(V((w,), birth(filtration, w)))
+        end
+    else
+        nothing
+    end
+end
+
 """
     zeroth_intervals(filtration, cutoff, field_type, ::Val{reps})
 
@@ -192,13 +202,7 @@ function zeroth_intervals(filtration, cutoff, field_type, reps)
             # into a later interval.
             dead = birth(dset, i) > birth(dset, j) ? i : j
             if diam(sx) - birth(dset, dead) > cutoff
-                if reps
-                    representative = map(find_leaves!(dset, dead)) do w
-                        CE(V((w,), birth(filtration, w)))
-                    end
-                else
-                    representative = nothing
-                end
+                representative = zeroth_representative(dset, dead, reps, CE, V)
                 interval = PersistenceInterval(birth(dset, dead), diam(sx), representative)
                 push!(intervals, interval)
             end
@@ -209,13 +213,7 @@ function zeroth_intervals(filtration, cutoff, field_type, reps)
     end
     for v in 1:n_vertices(filtration)
         if find_root!(dset, v) == v
-            if reps
-                representative = map(find_leaves!(dset, v)) do w
-                    CE(V((w,), birth(filtration, w)))
-                end
-            else
-                representative = nothing
-            end
+            representative = zeroth_representative(dset, v, reps, CE, V)
             push!(intervals, PersistenceInterval(birth(dset, v), ∞, representative))
         end
     end

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -167,8 +167,8 @@ end
 
 function zeroth_representative(dset, vertex, reps, CE, V)
     if reps
-        map(find_leaves!(dset, vertex)) do w
-            CE(V((w,), birth(dset, w)))
+        map(find_leaves!(dset, vertex)) do u
+            CE(V((u,), birth(dset, u)))
         end
     else
         nothing
@@ -311,10 +311,10 @@ function ripserer(
     filtration::AbstractFiltration;
     dim_max=1, representatives=false, cutoff=0, field_type=Mod{2}
 )
-    ripserer(filtration, cutoff, field_type, dim_max, representatives)
+    ripserer(filtration, cutoff, field_type, Val(dim_max), representatives)
 end
 
-function ripserer(filtration, cutoff, field_type, dim_max, reps)
+function ripserer(filtration, cutoff, field_type, ::Val{dim_max}, reps) where dim_max
     res = PersistenceDiagram[]
     res_0, cols, sxs = zeroth_intervals(filtration, cutoff, field_type, reps)
     push!(res, res_0)

--- a/src/reduction_structs.jl
+++ b/src/reduction_structs.jl
@@ -115,6 +115,11 @@ Base.empty!(col::Column) =
 Base.isempty(col::Column) =
     isempty(col.heap)
 
+function Base.sizehint!(col::Column, size)
+    sizehint!(col.heap, size)
+    col
+end
+
 """
     move_mul!(dst, col::Column{CE}, times=one(CE))
 

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -37,6 +37,9 @@ index(::IndexedSimplex)
 Base.sign(sx::IndexedSimplex) =
     sign(index(sx))
 
+Base.abs(sx::S) where S<:IndexedSimplex =
+    S(abs(index(sx)), diam(sx))
+
 Base.:-(sx::S) where S<:IndexedSimplex =
     S(-index(sx), diam(sx))
 
@@ -60,8 +63,6 @@ always positive.
 small_binomial(_, ::Val{0}) = 1
 small_binomial(n, ::Val{1}) = n
 function small_binomial(n, ::Val{k}) where k
-    n0, k0 = n, k
-    sgn = 1
     x = nn = n - k + 1
     nn += 1
     for rr in 2:k

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -5,41 +5,6 @@ using Compat
 
 include("data.jl")
 
-@testset "zeroth_intervals" begin
-    @testset "dense" begin
-        dist = [0 1 2;
-                1 0 3;
-                2 3 0]
-        flt = RipsFiltration(dist, threshold=3)
-        res, columns, simplices = zeroth_intervals(flt, 0, Mod{2}, Val(false))
-
-        @test !isnothing(simplices)
-        @test res == PersistenceDiagram(0, [(0, 1), (0, 2), (0, ∞)])
-        @test columns == [Simplex{1}(3, 3)]
-    end
-    @testset "sparse" begin
-        dist = [0 1 2;
-                1 0 0;
-                2 0 0]
-        flt = SparseRipsFiltration(dist)
-        res, columns, simplices = zeroth_intervals(flt, 0, Mod{5}, Val(false))
-
-        @test simplices == [Simplex{1}(1, 1),
-                            Simplex{1}(2, 2)]
-        @test res == PersistenceDiagram(0, [(0, 1), (0, 2), (0, ∞)])
-        @test isempty(columns)
-    end
-    @testset "birth" begin
-        dist = Float64[01 05 20 40;
-                       05 02 30 50;
-                       20 30 03 60;
-                       40 50 60 04]
-        flt = RipsFiltration(dist)
-        res, columns, simplices = zeroth_intervals(flt, 0, Rational{Int}, Val(false))
-        @test res == PersistenceDiagram(0, [(1.0, ∞), (2.0, 5.0), (3.0, 20.0), (4.0, 40.0)])
-    end
-end
-
 @testset "ripserer" begin
     @testset "full matrix, no threshold" begin
         @testset "icosahedron" begin


### PR DESCRIPTION
* Remove some unnecessary `@generated`s and `Val`s.
* Replace `columns` and `simplices` with `unreduced_columns` and `unreduced_simplices`. This should reduce memory usage.