### PR TITLE
Add Missing Import

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -23,7 +23,7 @@ using RecipesBase
 using TupleTools
 
 # reexport basics from PersistenceDiagrams
-import PersistenceDiagrams: birth
+import PersistenceDiagrams: birth, threshold
 export PersistenceDiagram, PersistenceInterval
 export birth, death, persistence, representative, barcode
 


### PR DESCRIPTION
There was a conflict for `threshold` when importing both Ripserer and PersistenceDiagrams.