### PR TITLE
Simplices are Arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ PersistenceDiagrams = "90b4794c-894b-4756-a0f8-5efeb5ddf7ae"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Compat = "3.10.0"
@@ -27,6 +28,7 @@ PersistenceDiagrams = "0.4"
 ProgressMeter = "1"
 RecipesBase = "1"
 StaticArrays = "0.12"
+TupleTools = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -16,7 +16,6 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Compat = "3.10.0"
@@ -27,7 +26,7 @@ IterTools = "1"
 PersistenceDiagrams = "0.4"
 ProgressMeter = "1"
 RecipesBase = "1"
-TupleTools = "1"
+StaticArrays = "0.12"
 julia = "1"
 
 [extras]

--- a/benchmark/bench_image.jl
+++ b/benchmark/bench_image.jl
@@ -6,8 +6,8 @@ hubble = getfield.(load(joinpath(@__DIR__, "hubble1024px.jpg")), :r)
 helix = getfield.(load(joinpath(@__DIR__, "helix_nebula1200px.jpg")), :r)
 suite = BenchmarkGroup()
 
-suite["helix"] = @benchmarkable ripserer(Cubical($helix))
-suite["hubble"] = @benchmarkable ripserer(Cubical($hubble))
+suite["helix"] = @benchmarkable ripserer(Cubical{Int128}($helix))
+suite["hubble"] = @benchmarkable ripserer(Cubical{Int128}($hubble))
 
 end
 BenchImage.suite

--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -20,6 +20,7 @@ using IterTools
 using PersistenceDiagrams
 using ProgressMeter
 using RecipesBase
+using StaticArrays
 using TupleTools
 
 # reexporting basics these makes Ripserer usable without having to import another package.

--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -21,7 +21,6 @@ using PersistenceDiagrams
 using ProgressMeter
 using RecipesBase
 using StaticArrays
-using TupleTools
 
 # reexporting basics these makes Ripserer usable without having to import another package.
 import PersistenceDiagrams: birth, threshold

--- a/src/Ripserer.jl
+++ b/src/Ripserer.jl
@@ -21,6 +21,7 @@ using PersistenceDiagrams
 using ProgressMeter
 using RecipesBase
 using StaticArrays
+using TupleTools
 
 # reexporting basics these makes Ripserer usable without having to import another package.
 import PersistenceDiagrams: birth, threshold

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -1,5 +1,5 @@
 """
-    AbstractFiltration{T, V<:AbstractSimplex{0, T}}
+    AbstractFiltration{T, S<:AbstractSimplex}
 
 A filtration is used to find the edges in filtration and to determine diameters of
 simplices.
@@ -11,19 +11,28 @@ simplices.
 
 * [`n_vertices(::AbstractFiltration)`](@ref)
 * [`edges(::AbstractFiltration)`](@ref)
-* [`diam(::AbstractFiltration, vs)`](@ref)
-* [`diam(::AbstractFiltration, ::AbstractSimplex, ::Any, ::Any)`](@ref)
+* [`diam(::AbstractFiltration, vertices)`](@ref)
+* [`diam(::AbstractFiltration, ::AbstractSimplex, ::Any, ::Any)`](@ref) - only used for
+  `Simplex`.
 * [`birth(::AbstractFiltration, v)`](@ref) - optional, defaults to returning `zero(T)`.
 * [`threshold(::AbstractFiltration)`](@ref) - optional, defaults to returning `missing`.
+* [`simplex_type(::AbstractFiltration, dim)`](@ref)
 """
-abstract type AbstractFiltration{T, V<:AbstractSimplex{0, T}} end
+abstract type AbstractFiltration{T, S<:AbstractSimplex} end
 
 function Base.show(io::IO, flt::AbstractFiltration)
     print(io, typeof(flt), "(n_vertices=$(n_vertices(flt)))")
 end
 
-vertex_type(::AbstractFiltration{<:Any, V}) where V = V
-edge_type(::AbstractFiltration{<:Any, V}) where V = coface_type(V)
+"""
+    simplex_type(::AbstractFiltration, dim)
+
+Return the `dim`-dimensional simplex in the filtration.
+"""
+simplex_type(::AbstractFiltration, dim)
+
+vertex_type(flt::AbstractFiltration) = simplex_type(flt, 0)
+edge_type(flt::AbstractFiltration) = simplex_type(flt, 1)
 dist_type(::AbstractFiltration{T}) where T = T
 
 """

--- a/src/abstractsimplex.jl
+++ b/src/abstractsimplex.jl
@@ -1,9 +1,12 @@
 """
-    AbstractSimplex{D, T}
+    AbstractSimplex{D, T, I} <: AbstractVector{I}
 
 An abstract type for representing simplices. A simplex must have a diameter of type `T`,
 which is its birth time. The dimension must be encoded in the type as `D` and can be
 accessed by [`dim`](@ref).
+
+The simplex is expected to act like an array of indices of type `I`, but this is not
+actually needed for the main algorithm.
 
 # Interface
 
@@ -18,7 +21,7 @@ accessed by [`dim`](@ref).
 * [`face_type(::AbstractSimplex)`](@ref) only required for homology.
 * [`boundary(::Any, ::AbstractSimplex)`](@ref) only required for homology.
 """
-abstract type AbstractSimplex{D, T} end
+abstract type AbstractSimplex{D, T, I} <: AbstractVector{I} end
 
 """
     diam(simplex::AbstractSimplex)

--- a/src/abstractsimplex.jl
+++ b/src/abstractsimplex.jl
@@ -18,8 +18,9 @@ actually needed for the main algorithm.
 * [`vertices(::AbstractSimplex)`](@ref)
 * [`coface_type(::AbstractSimplex)`](@ref)
 * [`coboundary(::Any, ::AbstractSimplex)`](@ref)
-* [`face_type(::AbstractSimplex)`](@ref) only required for homology.
-* [`boundary(::Any, ::AbstractSimplex)`](@ref) only required for homology.
+* [`face_type(::AbstractSimplex)`](@ref) - only required for homology.
+* [`boundary(::Any, ::AbstractSimplex)`](@ref) - only required for homology.
+* [`check_overflow(::Type{<:AbstractSimplex}, ::Any)`](@ref) - optional.
 """
 abstract type AbstractSimplex{D, T, I} <: AbstractVector{I} end
 
@@ -71,7 +72,10 @@ Base.:-(::AbstractSimplex)
 Base.:+(sx::AbstractSimplex) = sx
 
 Base.:(==)(::AbstractSimplex, ::AbstractSimplex) = false
-function Base.:(==)(sx1::AbstractSimplex{D}, sx2::AbstractSimplex{D}) where D
+function Base.:(==)(sx1::A, sx2::A) where A<:AbstractSimplex
+    return diam(sx1) == diam(sx2) && vertices(sx1) == vertices(sx2)
+end
+function Base.isequal(sx1::A, sx2::A) where A<:AbstractSimplex
     return diam(sx1) == diam(sx2) && vertices(sx1) == vertices(sx2)
 end
 Base.hash(sx::AbstractSimplex, h::UInt64) = hash(vertices(sx), hash(diam(sx), h))

--- a/src/cubical.jl
+++ b/src/cubical.jl
@@ -69,9 +69,7 @@ images, which are of type `AbstractArray{T, N}`.
 
     Cubical(::AbstractArray{T, N})
 """
-struct Cubical{
-    I, T, N, V<:Cubelet{0, T, I}, A<:AbstractArray{T, N}
-} <: AbstractFiltration{T, V}
+struct Cubical{I, T, N, A<:AbstractArray{T, N}} <: AbstractFiltration{T, Cubelet}
     data::A
     threshold::T
 end
@@ -80,18 +78,18 @@ function Cubical(data)
     return Cubical{Int}(data)
 end
 function Cubical{I}(data::AbstractArray{T, N}) where {I, T, N}
-    V = Cubelet{0, T, I}
-    return Cubical{I, T, N, V, typeof(data)}(data, maximum(data))
+    return Cubical{I, T, N, typeof(data)}(data, maximum(data))
 end
 
 n_vertices(cf::Cubical) = length(cf.data)
 threshold(cf::Cubical) = cf.threshold
 birth(cf::Cubical, i) = cf.data[i]
+simplex_type(::Cubical{I, T}, dim) where {I, T} = Cubelet{dim, T, I}
 
 Base.CartesianIndices(cf::Cubical) = CartesianIndices(cf.data)
 Base.LinearIndices(cf::Cubical) = LinearIndices(cf.data)
 
-function diam(cf::Cubical{T}, vertices) where {T}
+function diam(cf::Cubical{<:Any, T}, vertices) where {T}
     res = typemin(T)
     for v in vertices
         if isnothing(get(cf.data, v, nothing))

--- a/src/cubical.jl
+++ b/src/cubical.jl
@@ -8,29 +8,36 @@ nothing about the image it came from, it returns *linear* indices from `vertices
 The vertices should be neighboring indices, but this fact is not checked anywhere.
 """
 struct Cubelet{D, T, I} <: IndexedSimplex{D, T, I}
-    index ::I
-    diam  ::T
+    # This is not the most efficient way to index Cubelets, since most of the indices remain
+    # unused. It forces us to use large Int types for decently sized images. It does,
+    # however, make comparisons very fast, which is good.
+    index::I
+    diam::T
 
-    function Cubelet{D, T, I}(index, diam) where {D, T, I}
+    function Cubelet{D, T, I}(index::Integer, diam) where {D, T, I<:Integer}
         D ≥ 0 || throw(DomainError(D, "dimension must be a non-negative integer"))
         return new{D, T, I}(I(index), T(diam))
     end
 end
-Cubelet{D}(index::I, diam::T) where {D, T, I} = Cubelet{D, T, I}(index, diam)
 
-function Cubelet{D}(vertices::NTuple{K, I}, diam::T) where {D, T, K, I}
-    K == 2^D || throw(ArgumentError("a `Cubelet` must have 2^D simplices"))
-    return Cubelet{D, T, I}(index(vertices), diam)
+function Cubelet{D}(index::I, diam::T) where {D, T, I<:Integer}
+    return Cubelet{D, T, I}(index, diam)
 end
-function Cubelet{D, T, I}(vertices::NTuple, diam) where {D, T, I}
-    return Cubelet{D, T, I}(index(vertices), diam)
+function Cubelet{D}(vertices, diam::T) where {D, T}
+    return Cubelet{D, T, eltype(vertices)}(vertices, diam)
+end
+@generated function Cubelet{D, T, I}(vertices, diam) where {D, T, I<:Integer}
+    K = 2^D
+    return quote
+        length(vertices) == $K ||
+            throw(ArgumentError(string("a `Cubelet{",$D,"}` must have ",$K," simplices")))
+        vertices_svec = sort(SVector{$K, $I}(vertices), rev=true)
+        return Cubelet{$D, $T, $I}(index(vertices_svec), $T(diam))
+    end
 end
 
 function Base.show(io::IO, ::MIME"text/plain", csx::Cubelet{D, T, I}) where {D, T, I}
     print(io, D, "-dim Cubelet", (index(csx), diam(csx)))
-    if I ≢ Int64
-        print(io, " with ", I, " index")
-    end
     print(io, ":\n  $(sign(csx) == 1 ? '+' : '-')$(vertices(csx))")
 end
 
@@ -38,16 +45,19 @@ function Base.show(io::IO, csx::Cubelet{D, M}) where {D, M}
     print(io, "Cubelet{$D}($(sign(csx) == 1 ? '+' : '-')$(vertices(csx)), $(diam(csx)))")
 end
 
-diam(csx::Cubelet) = csx.diam
 index(csx::Cubelet) = csx.index
+diam(csx::Cubelet) = csx.diam
+coface_type(::Type{Cubelet{D, T, I}}) where {D, T, I} = Cubelet{D + 1, T, I}
+face_type(::Type{Cubelet{D, T, I}}) where {D, T, I} = Cubelet{D - 1, T, I}
 
 # @generated used because inference doesn't work well for 2^D
 @generated function vertices(csx::Cubelet{D, <:Any, I}) where {D, I}
     return :(vertices(index(csx), Val($(2^D))))
 end
 
-coface_type(::Type{Cubelet{D, T, I}}) where {D, T, I} = Cubelet{D + 1, T, I}
-face_type(::Type{Cubelet{D, T, I}}) where {D, T, I} = Cubelet{D - 1, T, I}
+Base.lastindex(sx::Cubelet{D}) where D = 2^D
+Base.size(sx::Cubelet{D}) where D = (2^D,)
+
 
 """
     Cubical{T, N} <: AbstractFiltration{T, <:Cubelet{0, T}}
@@ -60,17 +70,18 @@ images, which are of type `AbstractArray{T, N}`.
     Cubical(::AbstractArray{T, N})
 """
 struct Cubical{
-    T, N, V<:Cubelet{0, T}, A<:AbstractArray{T, N}
+    I, T, N, V<:Cubelet{0, T, I}, A<:AbstractArray{T, N}
 } <: AbstractFiltration{T, V}
-    data      ::A
-    threshold ::T
+    data::A
+    threshold::T
 end
 
-function Cubical(
-    data::AbstractArray{T, N};
-    vertex_type::DataType=Cubelet{0, T, Int64}
-) where {T, N}
-    return Cubical{T, N, vertex_type, typeof(data)}(data, maximum(data))
+function Cubical(data)
+    return Cubical{Int}(data)
+end
+function Cubical{I}(data::AbstractArray{T, N}) where {I, T, N}
+    V = Cubelet{0, T, I}
+    return Cubical{I, T, N, V, typeof(data)}(data, maximum(data))
 end
 
 n_vertices(cf::Cubical) = length(cf.data)
@@ -80,7 +91,6 @@ birth(cf::Cubical, i) = cf.data[i]
 Base.CartesianIndices(cf::Cubical) = CartesianIndices(cf.data)
 Base.LinearIndices(cf::Cubical) = LinearIndices(cf.data)
 
-# doesn't quite follow interface.
 function diam(cf::Cubical{T}, vertices) where {T}
     res = typemin(T)
     for v in vertices
@@ -93,16 +103,18 @@ function diam(cf::Cubical{T}, vertices) where {T}
     return res
 end
 
-function edges(cf::Cubical{<:Any, N}) where N
+function edges(cf::Cubical{I, <:Any, N}) where {I, N}
     E = edge_type(cf)
     result = E[]
     for u_lin in eachindex(cf.data)
         u_car = CartesianIndices(cf)[u_lin]
         for dim in 1:N
-            v_car = u_car + CartesianIndex(ntuple(i -> i == dim ? 1 : 0, N))
+            v_car = u_car + CartesianIndex{N}(ntuple(i -> i == dim ? 1 : 0, N))
             if v_car in CartesianIndices(cf)
                 v_lin = LinearIndices(cf)[v_car]
-                push!(result, E(index((v_lin, u_lin)), max(cf.data[u_lin], cf.data[v_lin])))
+                push!(result, E(
+                    index((I(v_lin), I(u_lin))), max(cf.data[u_lin], cf.data[v_lin])
+                ))
             end
         end
     end
@@ -110,19 +122,18 @@ function edges(cf::Cubical{<:Any, N}) where N
 end
 
 # coboundary ============================================================================= #
-struct CubeletCoboundary{A, N, C<:Cubelet, F<:Cubical{<:Any, N}, K}
-    filtration ::F
-    cubelet    ::C
-    vertices   ::NTuple{K, CartesianIndex{N}}
+struct CubeletCoboundary{A, N, I, C<:Cubelet, F<:Cubical{I, <:Any, N}, K}
+    filtration::F
+    cubelet::C
+    vertices::SVector{K, CartesianIndex{N}}
 end
 
 function CubeletCoboundary{A}(
     filtration::F, cubelet::C
-) where {A, N, D, F<:Cubical{<:Any, N}, C<:Cubelet{D}}
-
+) where {A, N, I, D, F<:Cubical{I, <:Any, N}, C<:Cubelet{D, <:Any, I}}
     K = 2^D
     vxs = map(v -> CartesianIndices(filtration)[v], vertices(cubelet))
-    return CubeletCoboundary{A, N, C, F, K}(filtration, cubelet, vxs)
+    return CubeletCoboundary{A, N, I, C, F, K}(filtration, cubelet, vxs)
 end
 
 function coboundary(filtration::Cubical, cubelet::Cubelet)
@@ -140,14 +151,16 @@ function all_equal_in_dim(dim, vertices)
     return true
 end
 
-function Base.iterate(cc::CubeletCoboundary{A, N, C}, (dim, dir)=(1, 1)) where {A, N, C}
+function Base.iterate(
+    cc::CubeletCoboundary{A, N, I, C}, (dim, dir)=(one(I), one(I))
+) where {A, N, I, C}
     # If not all indices in a given dimension are equal, we can't create a coface by
     # expanding in that direction.
     diameter = missing
     new_vertices = cc.vertices
     while ismissing(diameter)
         while dim ≤ N && !all_equal_in_dim(dim, cc.vertices)
-            dim += 1
+            dim += one(I)
         end
         if dim > N
             break
@@ -157,56 +170,58 @@ function Base.iterate(cc::CubeletCoboundary{A, N, C}, (dim, dir)=(1, 1)) where {
         new_vertices = cc.vertices .+ Ref(diff)
         diameter = max(diam(cc.cubelet), diam(cc.filtration, new_vertices))
 
-        dim += Int(dir == -1)
-        dir *= -1
+        dim += I(dir == -1)
+        dir *= -one(I)
     end
 
     if ismissing(diameter)
         return nothing
-    # We swapped the direction of dir at the end of the loop so we use -dir everywhere.
-    elseif dir == -1
-        all_vertices = map(v -> LinearIndices(cc.filtration)[v],
-                           TupleTools.vcat(new_vertices, cc.vertices))
     else
-        all_vertices = map(v -> LinearIndices(cc.filtration)[v],
-                           TupleTools.vcat(cc.vertices, new_vertices))
+        all_vertices = sort(map(v -> I(LinearIndices(cc.filtration)[v]),
+                                vcat(cc.vertices, new_vertices)), rev=true)
+        return coface_type(C)(-dir * index(all_vertices), diameter), (dim, dir)
     end
-    all_vertices = TupleTools.sort(all_vertices, rev=true)
-    return coface_type(C)(-dir * index(all_vertices), diameter), (dim, dir)
 end
 
-struct CubeletBoundary{D, C<:Cubelet, N, F<:Cubical{<:Any, N}, K}
-    filtration ::F
-    cubelet    ::C
-    vertices   ::NTuple{K, CartesianIndex{N}}
+struct CubeletBoundary{D, I, C<:Cubelet, N, F<:Cubical{I, <:Any, N}, K}
+    filtration::F
+    cubelet::C
+    vertices::SVector{K, CartesianIndex{N}}
 end
 
 function CubeletBoundary(
     filtration::F, cubelet::C
-) where {N, D, F<:Cubical{<:Any, N}, C<:Cubelet{D}}
+) where {N, D, I, F<:Cubical{I, <:Any, N}, C<:Cubelet{D}}
 
     K = 2^D
     vxs = map(v -> CartesianIndices(filtration)[v], vertices(cubelet))
-    return CubeletBoundary{D, C, N, F, K}(filtration, cubelet, vxs)
+    return CubeletBoundary{D, I, C, N, F, K}(filtration, cubelet, vxs)
 end
 
 boundary(filtration::Cubical, cubelet::Cubelet) = CubeletBoundary(filtration, cubelet)
 
+function first_half(vec::SVector{K, T}) where {K, T}
+    SVector{K÷2, T}(Tuple(vec)[1:K÷2])
+end
+function second_half(vec::SVector{K, T}) where {K, T}
+    SVector{K÷2, T}(Tuple(vec)[K÷2+1:K])
+end
+
 # Idea: split the cube in each dimension, returning two halves depending on dir.
-function Base.iterate(cb::CubeletBoundary{D, C}, (dim, dir)=(1, 1)) where {D, C}
+function Base.iterate(cb::CubeletBoundary{D, I, C}, (dim, dir)=(1, 1)) where {D, I, C}
     if dim > D
         return nothing
     else
-        lin_vertices = map(v -> LinearIndices(cb.filtration)[v],
-                           TupleTools.sort(cb.vertices, by=v -> v[dim], rev=true))
+        lin_vertices = map(v -> I(LinearIndices(cb.filtration)[v]),
+                           sort(cb.vertices, by=v -> v[dim], rev=true))
         if dir == 1
-            new_vertices = lin_vertices[1:end÷2]
+            new_vertices = first_half(lin_vertices)
             diameter = diam(cb.filtration, new_vertices)
-            return face_type(C)(index(new_vertices), diameter), (dim, -dir)
+            return face_type(C)(new_vertices, diameter), (dim, -dir)
         else
-            new_vertices = lin_vertices[end÷2+1:end]
+            new_vertices = second_half(lin_vertices)
             diameter = diam(cb.filtration, new_vertices)
-            return face_type(C)(-index(new_vertices), diameter), (dim + 1, 1)
+            return -face_type(C)(new_vertices, diameter), (dim + 1, 1)
         end
     end
 end

--- a/src/reductionmatrix.jl
+++ b/src/reductionmatrix.jl
@@ -289,7 +289,7 @@ function add!(matrix::ReductionMatrix, column, factor)
     return matrix
 end
 
-function reduce_column!(matrix::ReductionMatrix, column_simplex, cutoff, ::Type{I}) where I
+function reduce_column!(matrix::ReductionMatrix, column_simplex)
     pivot = initialize_boundary!(matrix, column_simplex)
 
     while !isnothing(pivot)
@@ -306,7 +306,7 @@ function reduce_column!(matrix::ReductionMatrix, column_simplex, cutoff, ::Type{
         commit!(matrix.reduced, simplex(pivot), inv(coefficient(pivot)))
     end
 
-    return interval(I, matrix, column_simplex, pivot, cutoff)
+    return pivot
 end
 
 function birth_death(matrix::ReductionMatrix{true}, simplex, pivot)
@@ -365,12 +365,13 @@ function compute_intervals!(
         )
     end
     for column in matrix.columns_to_reduce
-        interval = reduce_column!(matrix, column, cutoff, eltype(intervals))
-        if !isnothing(interval)
-            push!(intervals, interval)
+        pivot = reduce_column!(matrix, column)
+        int = interval(eltype(intervals), matrix, column, pivot, cutoff)
+        if !isnothing(int)
+            push!(intervals, int)
         end
         progress && next!(progbar)
-    end
+   end
     return sort!(
         PersistenceDiagram(dim(matrix), intervals, threshold(matrix.filtration))
     )

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -175,6 +175,9 @@ where ``i_k`` are the simplex vertex indices.
     return expr
 end
 
+index(vertex::Integer) = vertex
+index(vertex::CartesianIndex) = index(vertex.I)
+
 # (co)boundaries ========================================================================= #
 struct IndexedCobounary{all_cofaces, D, I, F, S<:IndexedSimplex}
     filtration ::F
@@ -269,15 +272,15 @@ Simplex{2}(2, 1)
 # output
 
 2-dim Simplex{2}(2, 1):
-  +(4, 2, 1)
+  +[4, 2, 1]
 ```
 ```jldoctest
 Simplex{10}(Int128(-10), 1.0)
 
 # output
 
-4-dim Simplex{3}(1.0, 10, 2) with UInt128 index:
-  -(12, 11, 10, 9, 8, 7, 6, 5, 4, 2, 1)
+4-dim Simplex{3}(1.0, 10, 2):
+  -Int128[12, 11, 10, 9, 8, 7, 6, 5, 4, 2, 1]
 ```
 """
 struct Simplex{D, T, I} <: IndexedSimplex{D, T, I}
@@ -293,7 +296,7 @@ end
 function Simplex{D}(index::I, diam::T) where {D, T, I<:Integer}
     return Simplex{D, T, I}(index, diam)
 end
-function Simplex{D}(vertices, diam::T) where {D, T, I<:Integer}
+function Simplex{D}(vertices, diam::T) where {D, T}
     return Simplex{D, T, eltype(vertices)}(vertices, diam)
 end
 function Simplex{D, T, I}(vertices, diam) where {D, T, I<:Integer}
@@ -305,9 +308,6 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", sx::Simplex{D, T, I}) where {D, T, I}
     print(io, D, "-dim Simplex", (index(sx), diam(sx)))
-    if I ≢ Int64
-        print(io, " with ", I, " index")
-    end
     print(io, ":\n  $(sign(sx) == 1 ? '+' : '-')$(vertices(sx))")
 end
 

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -1,9 +1,10 @@
 """
-    IndexedSimplex{D, T, I<:Integer} <: AbstractSimplex{D, T}
+    IndexedSimplex{D, T, I<:Integer} <: AbstractSimplex{D, T, I}
 
 A refinement of [`AbstractSimplex`](@ref). An indexed simplex is represented by its
-dimension, diameter and combinatorial index. It does not need to hold information about its
-the vertices it includes, since they can be recomputed from the index and dimension.
+dimension, diameter and combinatorial index of type `I`. It does not need to hold
+information about the vertices it includes, since they can be recomputed from the index
+and dimension.
 
 By defining the [`index`](@ref), a default implementation of `sign`, `isless`,
 [`vertices`](@ref) and [`coboundary`](@ref) is provided.
@@ -16,7 +17,7 @@ By defining the [`index`](@ref), a default implementation of `sign`, `isless`,
 * [`coface_type(::AbstractSimplex)`](@ref)
 * [`index(::IndexedSimplex)`](@ref)
 """
-abstract type IndexedSimplex{D, T, I<:Integer} <: AbstractSimplex{D, T} end
+abstract type IndexedSimplex{D, T, I<:Integer} <: AbstractSimplex{D, T, I} end
 
 """
     index(simplex::IndexedSimplex)
@@ -52,6 +53,12 @@ end
 function Base.hash(sx::IndexedSimplex, h::UInt64)
     return hash(index(sx), hash(diam(sx), h))
 end
+
+Base.eltype(sx::IndexedSimplex{<:Any, <:Any, I}) where I = I
+Base.getindex(sx::IndexedSimplex, i) = vertices(sx)[i]
+Base.firstindex(sx::IndexedSimplex) = 1
+Base.lastindex(sx::IndexedSimplex{D}) where D = D + 1
+Base.size(sx::IndexedSimplex{D}) where D = (D + 1,)
 
 # vertices and indices =================================================================== #
 """
@@ -106,7 +113,7 @@ end
 Get the vertices of simplex represented by index. Returns `NTuple{N, I}`.
 For regular simplices, `N` should be equal to `dim+1`!
 """
-@generated function vertices(index::I, ::Val{N})::NTuple{N, I} where {I, N}
+@generated function vertices(index::I, ::Val{N})::SVector{N, I} where {I, N}
     # Generate code of the form
     # index = abs(index) - 1
     # vk   = find_max_vertex(index, Val(k))
@@ -131,12 +138,12 @@ For regular simplices, `N` should be equal to `dim+1`!
     end
     return quote
         $expr
-        (tuple($(vars...)) .+ I(1))
+        SVector($(vars...)) .+ I(1)
     end
 end
 
 function vertices(sx::IndexedSimplex{D, <:Any, I}) where {D, I}
-    return vertices(index(sx), Val(D+1))::NTuple{D+1, I}
+    return vertices(index(sx), Val(D+1))::SVector{D+1, I}
 end
 
 """
@@ -150,7 +157,7 @@ Calculate the index from tuple of vertices. The index is equal to
 
 where ``i_k`` are the simplex vertex indices.
 """
-@generated function index(vertices::NTuple{k}) where k
+@generated function index(vertices::Union{NTuple{k}, SVector{k}}) where k
     # generate code of the form
     # 1 + small_binomial(vertices[1] - 1, Val(k))
     #   + small_binomial(vertices[2] - 1, Val(k-1))
@@ -169,16 +176,15 @@ where ``i_k`` are the simplex vertex indices.
 end
 
 # (co)boundaries ========================================================================= #
-struct IndexedCobounary{all_cofaces, D, F, S<:IndexedSimplex}
+struct IndexedCobounary{all_cofaces, D, I, F, S<:IndexedSimplex}
     filtration ::F
     simplex    ::S
-    vertices   ::NTuple{D, Int}
+    vertices   ::SVector{D, I}
 
     function IndexedCobounary{A}(
         filtration::F, simplex::S
-    ) where {A, D, F, S<:IndexedSimplex{D}}
-
-        return new{A, D + 1, F, S}(filtration, simplex, vertices(simplex))
+    ) where {A, D, I, F, S<:IndexedSimplex{D, <:Any, I}}
+        return new{A, D + 1, I, F, S}(filtration, simplex, vertices(simplex))
     end
 end
 
@@ -187,8 +193,8 @@ function coboundary(filtration, simplex::IndexedSimplex, ::Val{A}=Val(true)) whe
 end
 
 function Base.iterate(
-    ci::IndexedCobounary{all_cofaces, D}, (v, k)=(n_vertices(ci.filtration) + 1, D),
-) where {all_cofaces, D}
+    ci::IndexedCobounary{all_cofaces, D, I}, (v, k)=(n_vertices(ci.filtration) + 1, D),
+) where {all_cofaces, D, I}
 
     diameter = missing
     @inbounds while ismissing(diameter) && v > 0
@@ -202,8 +208,8 @@ function Base.iterate(
         diameter = diam(ci.filtration, ci.simplex, ci.vertices, v)
     end
     if !ismissing(diameter)
-        sign = ifelse(iseven(k), 1, -1)
-        new_index = index(TupleTools.insertafter(ci.vertices, D - k, (v,))) * sign
+        sign = ifelse(iseven(k), one(I), -one(I))
+        new_index = index(insert(ci.vertices, D - k + 1, v)) * sign
 
         return coface_type(ci.simplex)(new_index, diameter), (v, k)
     else
@@ -211,13 +217,15 @@ function Base.iterate(
     end
 end
 
-struct IndexedBoundary{D, F, S<:IndexedSimplex}
+struct IndexedBoundary{D, I, F, S<:IndexedSimplex}
     filtration::F
     simplex::S
-    vertices::NTuple{D, Int}
+    vertices::SVector{D, I}
 
-    function IndexedBoundary(filtration::F, simplex::S) where {D, F, S<:IndexedSimplex{D}}
-        return new{D + 1, F, S}(filtration, simplex, vertices(simplex))
+    function IndexedBoundary(
+        filtration::F, simplex::S
+    ) where {D, I, F, S<:IndexedSimplex{D, <:Any, I}}
+        return new{D + 1, I, F, S}(filtration, simplex, vertices(simplex))
     end
 end
 
@@ -225,16 +233,16 @@ function boundary(filtration, simplex::IndexedSimplex)
     return IndexedBoundary(filtration, simplex)
 end
 
-function Base.iterate(bi::IndexedBoundary{D}, k=1) where D
+function Base.iterate(bi::IndexedBoundary{D, I}, k=1) where {D, I}
     diameter = missing
-    face_vertices = TupleTools.unsafe_tail(bi.vertices)
+    face_vertices = zeros(SVector{D - 1, I})
     while ismissing(diameter) && k ≤ D
-        face_vertices = TupleTools.deleteat(bi.vertices, k)
+        face_vertices = deleteat(bi.vertices, k)
         diameter = diam(bi.filtration, face_vertices)
         k += 1
     end
     if !ismissing(diameter)
-        sign = ifelse(iseven(k), 1, -1)
+        sign = ifelse(iseven(k), one(I), -one(I))
         new_index = index(face_vertices) * sign
 
         return face_type(bi.simplex)(new_index, diameter), k
@@ -276,7 +284,7 @@ struct Simplex{D, T, I} <: IndexedSimplex{D, T, I}
     index ::I
     diam  ::T
 
-    function Simplex{D, T, I}(index, diam) where {D, T, I}
+    function Simplex{D, T, I}(index::Integer, diam) where {D, T, I<:Integer}
         D ≥ 0 || throw(DomainError(D, "dimension must be a non-negative integer"))
         return new{D, T, I}(I(index), T(diam))
     end
@@ -285,12 +293,14 @@ end
 function Simplex{D}(index::I, diam::T) where {D, T, I<:Integer}
     return Simplex{D, T, I}(index, diam)
 end
-function Simplex{D}(vertices::NTuple{<:Any, I}, diam::T) where {D, T, I<:Integer}
-    return Simplex{D, T, I}(vertices, diam)
+function Simplex{D}(vertices, diam::T) where {D, T, I<:Integer}
+    return Simplex{D, T, eltype(vertices)}(vertices, diam)
 end
-function Simplex{D, T, I}(vertices::NTuple{N}, diam) where {D, T, I<:Integer, N}
-    N == D + 1 || throw(ArgumentError("invalid number of vertices"))
-    return Simplex{D, T, I}(index(vertices), T(diam))
+function Simplex{D, T, I}(vertices, diam) where {D, T, I<:Integer}
+    length(vertices) == D + 1 ||
+        throw(ArgumentError("invalid number of vertices $(length(vertices))"))
+    vertices_svec = sort(SVector{D + 1}(vertices), rev=true)
+    return Simplex{D, T, I}(index(vertices_svec), T(diam))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", sx::Simplex{D, T, I}) where {D, T, I}

--- a/src/zerodimensional.jl
+++ b/src/zerodimensional.jl
@@ -108,7 +108,7 @@ function zeroth_intervals(
         progbar = Progress(length(simplices), desc="Computing 0d intervals... ")
     end
     for sx in simplices
-        u, v = vertices(sx)
+        u, v = index.(vertices(sx))
         i = find_root!(dset, u)
         j = find_root!(dset, v)
         if i ≠ j

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,4 +1,5 @@
 using Ripserer
 using Aqua
 
-Aqua.test_all(Ripserer)
+# Ignore ambiguities in StaticArrays.
+Aqua.test_all(Ripserer, ambiguities=(exclude=[Base.convert, Base.unsafe_convert],))

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -2,4 +2,4 @@ using Ripserer
 using Aqua
 
 # Ignore ambiguities in StaticArrays.
-Aqua.test_all(Ripserer, ambiguities=(exclude=[Base.convert, Base.unsafe_convert],))
+Aqua.test_all(Ripserer, ambiguities=(exclude=[Base.convert, Base.unsafe_convert, Base.all],))

--- a/test/cubical.jl
+++ b/test/cubical.jl
@@ -1,4 +1,6 @@
 using Ripserer
+using StaticArrays
+
 using Ripserer: all_equal_in_dim
 
 data1d = cos.(range(0, 4π, length=1000))
@@ -19,11 +21,11 @@ using ..TestHelpers: test_indexed_simplex_interface, test_filtration_interface
     test_indexed_simplex_interface(Cubelet, D -> 2^D)
 
     @testset "vertices, index" begin
-        @test vertices(Cubelet{2}(1, rand())) == (4, 3, 2, 1)
-        @test vertices(Cubelet{2}(2, rand())) == (5, 3, 2, 1)
-        @test vertices(Cubelet{1}(3, rand())) == (3, 2)
-        @test vertices(Cubelet{0}(4, rand())) == (4,)
-        @test vertices(Cubelet{3}(5, rand())) == (9, 8, 7, 6, 4, 3, 2, 1)
+        @test vertices(Cubelet{2}(1, rand())) == SVector{4}(4, 3, 2, 1)
+        @test vertices(Cubelet{2}(Int128(2), rand())) == SVector{4, Int128}(5, 3, 2, 1)
+        @test vertices(Cubelet{1}(3, rand())) == SVector{2}(3, 2)
+        @test vertices(Cubelet{0}(Int32(4), rand())) == SVector{1, Int32}(4)
+        @test vertices(Cubelet{3}(5, rand())) == SVector{8}(9, 8, 7, 6, 4, 3, 2, 1)
 
         for i in 1:20
             sx = Cubelet{5}(i, rand())
@@ -34,16 +36,16 @@ using ..TestHelpers: test_indexed_simplex_interface, test_filtration_interface
         end
     end
     @testset "show" begin
-        @test sprint(print, Cubelet{1}(1, 1)) == "Cubelet{1}(+(2, 1), 1)"
-        @test sprint(print, Cubelet{2}(-1, 1)) == "Cubelet{2}(-(4, 3, 2, 1), 1)"
+        @test sprint(print, Cubelet{1}(1, 1)) == "Cubelet{1}(+[2, 1], 1)"
+        @test sprint(print, Cubelet{2}(-1, 1)) == "Cubelet{2}(-[4, 3, 2, 1], 1)"
 
         @test sprint(Cubelet{2}(1, 1)) do io, sx
             show(io, MIME"text/plain"(), sx)
-        end == "2-dim Cubelet(1, 1):\n  +(4, 3, 2, 1)"
+        end == "2-dim Cubelet(1, 1):\n  +[4, 3, 2, 1]"
 
         @test sprint(Cubelet{1}(Int128(1), 1)) do io, sx
             show(io, MIME"text/plain"(), sx)
-        end == "1-dim Cubelet(1, 1) with Int128 index:\n  +(2, 1)"
+        end == "1-dim Cubelet(1, 1):\n  +Int128[2, 1]"
     end
 end
 

--- a/test/ripserer.jl
+++ b/test/ripserer.jl
@@ -253,13 +253,11 @@ end
             0 2 2 2 0;
             0 0 0 0 0]
 
-    d0, d1, d2, d3, d4 = ripserer(Cubical(data), reps=true, dim_max=4)
+    d0, d1, d2 = ripserer(Cubical(data), reps=true, dim_max=2)
 
     @test d0 == [(0, Inf), (1, 2)]
     @test d1 == [(0, 2)]
     @test isempty(d2)
-    @test isempty(d3)
-    @test isempty(d4)
 
     @test vertices.(representative(d0[1])) == [SVector(i) for i in 1:length(data)]
     @test vertices(only(representative(d0[2]))) == SVector(13)

--- a/test/ripserer.jl
+++ b/test/ripserer.jl
@@ -2,6 +2,7 @@ using Ripserer
 using Ripserer: zeroth_intervals, ChainElement, PackedElement
 
 using Compat
+using StaticArrays
 using Suppressor
 
 include("data.jl")
@@ -260,8 +261,8 @@ end
     @test isempty(d3)
     @test isempty(d4)
 
-    @test vertices.(representative(d0[1])) == [(i,) for i in 1:length(data)]
-    @test vertices(only(representative(d0[2]))) == (13,)
+    @test vertices.(representative(d0[1])) == [SVector(i) for i in 1:length(data)]
+    @test vertices(only(representative(d0[2]))) == SVector(13)
 end
 
 @testset "Persistent homology." begin
@@ -271,9 +272,9 @@ end
     @test res_hom == res_coh
 
     res_hom = ripserer(cycle, cohomology=false, reps=true, dim_max=3)
-    @test vertices.(simplex.(representative(res_hom[2][1]))) == sort!([
-        [(i+1, i) for i in 1:17]; (18, 1)
-    ])
+    @test vertices.(simplex.(representative(res_hom[2][1]))) == sort!(vcat(
+        [SVector(i+1, i) for i in 1:17], [SVector(18, 1)]
+    ))
 
     @test_broken ripserer(cycle, cohomology=false, threshold=2)[2][1] == (1.0, Inf)
 end

--- a/test/ripsfiltration.jl
+++ b/test/ripsfiltration.jl
@@ -93,11 +93,10 @@ for Filtration in (Rips, SparseRips)
             @test birth(flt, 4) == 0
         end
         @testset "threshold, vertex_type" begin
-            flt = Filtration([1 1 2;
-                              1 2 3;
-                              2 3 3];
-                             threshold=2,
-                             vertex_type=Simplex{0, Int, Int})
+            flt = Filtration{Int128}([1 1 2;
+                                      1 2 3;
+                                      2 3 2];
+                                     threshold=2)
 
             @test n_vertices(flt) == 3
             @test threshold(flt) == 2
@@ -107,26 +106,17 @@ for Filtration in (Rips, SparseRips)
             @test dist(flt, 3, 2) ≡ (issparse(flt.dist) ? missing : 3)
             @test ismissing(diam(flt, Simplex{2}(1, 1), [1, 2], 3))
             @test threshold(flt) == 2
-            @test vertex_type(flt) === Simplex{0, Int, Int}
-            @test edge_type(flt) === Simplex{1, Int, Int}
+            @test vertex_type(flt) === Simplex{0, Int, Int128}
+            @test edge_type(flt) === Simplex{1, Int, Int128}
 
             @test birth(flt, 1) == 1
             @test birth(flt, 2) == 2
-            @test birth(flt, 3) == 3
+            @test birth(flt, 3) == 2
         end
         @testset "errors" begin
             @test_throws ArgumentError Filtration([1 2 3;
                                                    4 5 6;
                                                    7 8 9])
-            dists = [0 1 2; 1 0 3; 2 3 0]
-            @test_throws ArgumentError Filtration(dists, vertex_type=Int)
-            @test_throws ArgumentError Filtration(
-                dists, vertex_type=Simplex{1, Int, Int}
-            )
-            @test_throws ArgumentError Filtration(
-                dists, vertex_type=Simplex{0, Float64, Int}
-            )
-            @test_throws TypeError Filtration(dists, vertex_type=Simplex{0, Int})
         end
     end
 end

--- a/test/simplex.jl
+++ b/test/simplex.jl
@@ -1,6 +1,7 @@
 using Ripserer
-using Ripserer: small_binomial
+using StaticArrays
 
+using Ripserer: small_binomial
 using ..TestHelpers: test_indexed_simplex_interface
 
 struct FakeFiltration end
@@ -19,16 +20,15 @@ Ripserer.n_vertices(::FakeFiltrationWithThreshold) =
     @test all(binomial(n, k) == small_binomial(n, Val(k)) for n in 0:1000 for k in 0:7)
 end
 
-
 @testset "Simplex" begin
     test_indexed_simplex_interface(Simplex, D->D+1)
 
     @testset "vertices, index" begin
-        @test vertices(Simplex{2}(1, rand())) ≡ (3, 2, 1)
-        @test vertices(Simplex{3}(Int32(2), rand())) ≡ Int32.((5, 3, 2, 1))
-        @test vertices(Simplex{1}(Int128(3), rand())) ≡ Int128.((3, 2))
-        @test vertices(Simplex{4}(4, rand())) ≡ (6, 5, 4, 2, 1)
-        @test vertices(Simplex{2}(5, rand())) ≡ (5, 2, 1)
+        @test vertices(Simplex{2}(1, rand())) ≡ SVector{3}(3, 2, 1)
+        @test vertices(Simplex{3}(Int32(2), rand())) ≡ SVector{4, Int32}(5, 3, 2, 1)
+        @test vertices(Simplex{1}(Int128(3), rand())) ≡ SVector{2, Int128}(3, 2)
+        @test vertices(Simplex{4}(4, rand())) ≡ SVector{5}(6, 5, 4, 2, 1)
+        @test vertices(Simplex{2}(5, rand())) ≡ SVector{3}(5, 2, 1)
 
         for i in 1:2:20
             for I in (Int64, Int32, Int128)
@@ -41,16 +41,16 @@ end
         end
     end
     @testset "show" begin
-        @test sprint(print, Simplex{1}(1, 1)) == "Simplex{1}(+(2, 1), 1)"
-        @test sprint(print, Simplex{2}(-1, 1)) == "Simplex{2}(-(3, 2, 1), 1)"
+        @test sprint(print, Simplex{1}(1, 1)) == "Simplex{1}(+[2, 1], 1)"
+        @test sprint(print, Simplex{2}(-1, 1)) == "Simplex{2}(-[3, 2, 1], 1)"
 
         @test sprint(Simplex{2}(1, 1)) do io, sx
             show(io, MIME"text/plain"(), sx)
-        end == "2-dim Simplex(1, 1):\n  +(3, 2, 1)"
+        end == "2-dim Simplex(1, 1):\n  +[3, 2, 1]"
 
         @test sprint(Simplex{1}(Int128(1), 1)) do io, sx
             show(io, MIME"text/plain"(), sx)
-        end == "1-dim Simplex(1, 1) with Int128 index:\n  +(2, 1)"
+        end == "1-dim Simplex(1, 1):\n  +Int128[2, 1]"
 
     end
     @testset "coboundary" begin


### PR DESCRIPTION
* `AbstractSimplex` is now a subtype of `AbstractVector`. Along with allowing us to treat them as collections of vertices. This allows us to index data with simplices directly.
* The `vertices` function now returns a `SVector`.
* `Cubelet`s now handle index types correctly in (co)boundary computation.
* `ripserer` now complains if simplex index is too small to represent all the simplices in filtration.
* It is now easier to set index type for filtrations.
* Performance tweaks and bugfixes.