### PR TITLE
Update PersistenceDiagrams

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -24,7 +24,7 @@ DataStructures = "0.17"
 Distances = "0.8, 0.9"
 Hungarian = "0.6"
 IterTools = "1"
-PersistenceDiagrams = "0.5, 0.6"
+PersistenceDiagrams = "0.7"
 ProgressMeter = "1"
 RecipesBase = "1"
 StaticArrays = "0.12"

--- a/docs/src/api/filtrations.md
+++ b/docs/src/api/filtrations.md
@@ -45,7 +45,7 @@ Ripserer.emergent_pairs
 ```
 
 ```@docs
-Ripserer.postprocess_interval
+Ripserer.postprocess_diagram
 ```
 
 ```@docs

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -159,15 +159,15 @@ postprocess_diagram(::AbstractFiltration, diagram) = sort!(diagram)
 
 function interval_meta_type(flt::AbstractFiltration, dim, reps, field)
     if reps
-        return @NamedTuple{
-            birth_simplex::simplex_type(flt, dim),
-            death_simplex::Union{simplex_type(flt, dim + 1), Nothing},
-            representative::Vector{chain_element_type(simplex_type(flt, dim), field)},
-        }
+        return @NamedTuple begin
+            birth_simplex::simplex_type(flt, dim)
+            death_simplex::Union{simplex_type(flt, dim + 1), Nothing}
+            representative::Vector{chain_element_type(simplex_type(flt, dim), field)}
+        end
     else
-        return @NamedTuple{
-            birth_simplex::simplex_type(flt, dim),
-            death_simplex::Union{simplex_type(flt, dim + 1), Nothing},
-        }
+        return @NamedTuple begin
+            birth_simplex::simplex_type(flt, dim)
+            death_simplex::Union{simplex_type(flt, dim + 1), Nothing}
+        end
     end
 end

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -17,7 +17,7 @@ A filtration is used to find the edges in filtration and to create simplices. An
 * [`threshold(::AbstractFiltration)`](@ref)
 * [`columns_to_reduce(::AbstractFiltration)`](@ref)
 * [`emergent_pairs(::AbstractFiltration)`](@ref)
-* [`postprocess_interval(::AbstractFiltration, ::Any)`](@ref)
+* [`postprocess_diagram(::AbstractFiltration, ::Any)`](@ref)
 """
 abstract type AbstractFiltration{I, T} end
 
@@ -150,12 +150,24 @@ correct order.
 emergent_pairs(::AbstractFiltration) = true
 
 """
-    postprocess_interval(::AbstractFiltration, interval)
+    postprocess_diagram(::AbstractFiltration, diagram)
 
-This function is called on each resulting persistence interval. If returns `nothing`, the
-interval is skipped. The default implementation returns the unchanged interval.
+This function is called on each resulting persistence diagram after all intervals have been
+computed. Defaults to sorting the diagram.
 """
-postprocess_interval(::AbstractFiltration, interval) = interval
+postprocess_diagram(::AbstractFiltration, diagram) = sort!(diagram)
 
-_postprocess_interval(flt, interval) = postprocess_interval(flt, interval)
-_postprocess_interval(flt, ::Nothing) = nothing
+function interval_meta_type(flt::AbstractFiltration, dim, reps, field)
+    if reps
+        return @NamedTuple{
+            birth_simplex::simplex_type(flt, dim),
+            death_simplex::Union{simplex_type(flt, dim + 1), Nothing},
+            representative::Vector{chain_element_type(simplex_type(flt, dim), field)},
+        }
+    else
+        return @NamedTuple{
+            birth_simplex::simplex_type(flt, dim),
+            death_simplex::Union{simplex_type(flt, dim + 1), Nothing},
+        }
+    end
+end

--- a/src/cubical.jl
+++ b/src/cubical.jl
@@ -62,7 +62,7 @@ function to_cubemap(vertices::NTuple{N}) where N
 end
 
 """
-    Cubelet{D, T, K} <: AbstractSimplex{D, T, CartesianIndex{K}}
+    Cube{D, T, K} <: AbstractSimplex{D, T, CartesianIndex{K}}
 
 A `Cube` is similar to a `Simplex`, but it has `2^D` vertices instead of `D+1`. The vertices
 are encoded as the position in the CubeMap.

--- a/src/simplexrecipes.jl
+++ b/src/simplexrecipes.jl
@@ -29,7 +29,7 @@ end
 
 """
     plottable(sx::AbstractSimplex, args...)
-    plottable(sx::RepresentativeInterval, args...)
+    plottable(sx::PersistenceInterval, args...)
     plottable(sx::Vector{<:AbstractSimplex}, args...)
 
 Turn `sx` into a series that can be plotted. `args...`, should contain the data which tells
@@ -38,7 +38,7 @@ the plot where to place simplex vertices.
 function plottable(sx::AbstractSimplex, args...)
     return plottable([sx], args...)
 end
-function plottable(int::RepresentativeInterval, args...)
+function plottable(int::PersistenceInterval, args...)
     return plottable(simplex.(representative(int)), args...)
 end
 function plottable(rep::AbstractVector{<:AbstractChainElement}, args...)
@@ -78,11 +78,12 @@ end
 function apply_threshold(els::AbstractVector{<:AbstractChainElement}, thresh, thresh_strict)
     return apply_threshold(simplex.(els), thresh, thresh_strict)
 end
-function apply_threshold(::PersistenceDiagrams.AbstractInterval, _, _)
-    error("interval has no representative. Run `ripserer` with `representatives=true`")
-end
-function apply_threshold(int::RepresentativeInterval, thresh, thresh_strict)
-    return apply_threshold(representative(int), thresh, thresh_strict)
+function apply_threshold(int::PersistenceInterval, thresh, thresh_strict)
+    if hasproperty(int, :representative)
+        return apply_threshold(representative(int), thresh, thresh_strict)
+    else
+        error("interval has no representative. Run `ripserer` with `representatives=true`")
+    end
 end
 
 @recipe function f(
@@ -91,8 +92,7 @@ end
         AbstractChainElement,
         AbstractVector{<:AbstractSimplex},
         AbstractVector{<:AbstractChainElement},
-        PersistenceDiagrams.AbstractInterval,
-        RepresentativeInterval,
+        PersistenceInterval,
     },
     args...;
     threshold=Inf,

--- a/src/zerodimensional.jl
+++ b/src/zerodimensional.jl
@@ -76,31 +76,26 @@ end
 
 birth(dset::DisjointSetsWithBirth, i) = dset.births[i]
 
-function birth_death(dset::DisjointSetsWithBirth, vertex, edge)
-    return birth(dset, vertex), isnothing(edge) ? Inf : birth(edge)
-end
-
-function interval(
-    ::Type{R}, dset::DisjointSetsWithBirth, filtration, vertex, edge, cutoff
-) where R<:RepresentativeInterval
-    birth, death = birth_death(dset, vertex, edge)
-    if death - birth > cutoff
-        rep = sort(simplex.(Ref(filtration), Val(0), tuple.(find_leaves!(dset, vertex))))
-        birth_simplex = first(rep)
-        return R(PersistenceInterval(birth, death), birth_simplex, edge, rep)
-    else
-        return nothing
-    end
-end
-
-function interval(
-    ::Type{PersistenceInterval}, dset::DisjointSetsWithBirth, _, vertex, edge, cutoff
+function add_interval!(
+    intervals, dset::DisjointSetsWithBirth, filtration, vertex, edge, cutoff, reps
 )
-    birth, death = birth_death(dset, vertex, edge)
-    if death - birth > cutoff
-        return PersistenceInterval(birth, death)
-    else
-        return nothing
+    birth_time = birth(dset, vertex)
+    death_time = isnothing(edge) ? Inf : birth(edge)
+    if death_time - birth_time > cutoff
+        birth_vertex = simplex(filtration, Val(0), (vertex,))
+        if reps
+            rep = (;representative=sort!(
+                [simplex(filtration, Val(0), (v,)) for v in find_leaves!(dset, vertex)]
+            ))
+        else
+            rep = NamedTuple()
+        end
+        push!(intervals, PersistenceInterval(
+            birth_time, death_time;
+            birth_simplex=birth_vertex,
+            death_simplex=edge,
+            rep...,
+        ))
     end
 end
 
@@ -119,16 +114,9 @@ function zeroth_intervals(
     V = vertex_type(filtration)
     CE = chain_element_type(V, F)
     dset = DisjointSetsWithBirth(vertices(filtration), birth(filtration))
-    if reps
-        intervals = RepresentativeInterval{
-            PersistenceInterval,
-            vertex_type(filtration),
-            Union{edge_type(filtration), Nothing},
-            Vector{CE},
-        }[]
-    else
-        intervals = PersistenceInterval[]
-    end
+
+    intervals = PersistenceInterval{interval_meta_type(filtration, 0, reps, F)}[]
+
     to_skip = edge_type(filtration)[]
     to_reduce = edge_type(filtration)[]
     simplices = sort!(edges(filtration))
@@ -143,16 +131,10 @@ function zeroth_intervals(
         i = find_root!(dset, u)
         j = find_root!(dset, v)
         if i ≠ j
-            # According to the elder rule, the vertex with the lower birth will fall
-            # into a later interval.
-            v = birth(dset, i) > birth(dset, j) ? i : j
-            int = _postprocess_interval(
-                filtration,
-                interval(eltype(intervals), dset, filtration, v, edge, cutoff),
-            )
-            if !isnothing(int)
-                push!(intervals, int)
-            end
+            # According to the elder rule, the vertex with the higer birth will die first.
+            birth_vertex = birth(dset, i) > birth(dset, j) ? i : j
+            add_interval!(intervals, dset, filtration, birth_vertex, edge, cutoff, reps)
+
             union!(dset, i, j)
             push!(to_skip, edge)
         else
@@ -162,20 +144,25 @@ function zeroth_intervals(
     end
     for v in vertices(filtration)
         if find_root!(dset, v) == v && !isnothing(simplex(filtration, Val(0), (v,), 1))
-            int = _postprocess_interval(
-                filtration,
-                interval(eltype(intervals), dset, filtration, v, nothing, 0)
-            )
-            if !isnothing(int)
-                push!(intervals, int)
-            end
+            add_interval!(intervals, dset, filtration, v, nothing, cutoff, reps)
         end
         progress && next!(progbar; showvalues=((:n_intervals, length(intervals)),))
     end
     reverse!(to_reduce)
     progress && printstyled(stderr, "Assembled $(length(to_reduce)) edges.\n", color=:green)
+
+    thresh = Float64(threshold(filtration))
     return (
-        sort!(PersistenceDiagram(0, intervals, threshold(filtration))),
+        postprocess_diagram(
+            filtration,
+            PersistenceDiagram(
+                intervals;
+                threshold=thresh,
+                dim=0,
+                field_type=F,
+                filtration=filtration,
+            ),
+        ),
         to_reduce,
         to_skip,
     )

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -50,8 +50,11 @@ series(args...; kwargs...) =
             @test length(series(sx, data)) == 1
             @test length(series([sx], data)) == 1
             @test length(series([sx], data)) == 1
-            @test length(series(RepresentativeInterval(
-                1.0, 1.0, sx, fsx, [ChainElement{typeof(sx), typeof(1//1)}(sx, 1//1)]
+            @test length(series(PersistenceInterval(
+                1.0, 1.0;
+                birth_simplex=sx,
+                death_simplex=fsx,
+                representative=[ChainElement{typeof(sx), typeof(1//1)}(sx, 1//1)],
             ), data)) == 1
             @test_throws ErrorException series(PersistenceInterval(1.0, 1.0), data)
         end

--- a/test/ripserer.jl
+++ b/test/ripserer.jl
@@ -244,6 +244,19 @@ end
         @test d0 == [(0, Inf), (1, 4), (2, 3)]
         @test d1 == []
     end
+    @testset "1D curve representatives" begin
+        n = 1000
+        x = range(0, 1, length=n)
+        curve = sin.(2π * 5x) .* x
+
+        d0, _ = ripserer(Cubical(curve), reps=true)
+
+        for int in d0
+            birth_sx = birth_simplex(int)
+            @test curve[only(birth_sx)] == birth(int) == birth(birth_sx)
+        end
+        @test only.(birth_simplex.(d0)) == CartesianIndex.([951, 752, 552, 354, 157, 1])
+    end
     @testset "2D image" begin
         data = [0 0 0 0 0;
                 0 2 2 2 0;

--- a/test/ripserer.jl
+++ b/test/ripserer.jl
@@ -6,7 +6,7 @@ using StaticArrays
 using Suppressor
 using Test
 
-using Ripserer: zeroth_intervals, ChainElement, PackedElement
+using Ripserer: ChainElement, PackedElement
 
 
 include("data.jl")
@@ -144,49 +144,19 @@ end
     end
     @testset "Types" begin
         d0, d1, d2, d3 = ripserer(cycle; dim_max=3, reps=true)
-        @test eltype(d0) <: RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{0, Int, Int},
-            Union{Nothing, Simplex{1, Int, Int}},
-            <:Vector{<:PackedElement{Simplex{0, Int, Int}, Mod{2}}}}
-        @test eltype(d1) <: RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{1, Int, Int},
-            Union{Nothing, Simplex{2, Int, Int}},
-            <:Vector{<:PackedElement{Simplex{1, Int, Int}, Mod{2}}}}
-        @test eltype(d2) <: RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{2, Int, Int},
-            Union{Nothing, Simplex{3, Int, Int}},
-            <:Vector{<:PackedElement{Simplex{2, Int, Int}, Mod{2}}}}
-        @test eltype(d3) <: RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{3, Int, Int},
-            Union{Nothing, Simplex{4, Int, Int}},
-            <:Vector{<:PackedElement{Simplex{3, Int, Int}, Mod{2}}}}
+        @test eltype(d0) isa DataType
+        @test eltype(d1) isa DataType
+        @test eltype(d2) isa DataType
+        @test eltype(d3) isa DataType
+        @test eltype(d1[1].representative) <: PackedElement
 
         d0, d1, d2, d3 = ripserer(cycle; dim_max=3, reps=true,
                                   field_type=Rational{Int})
-        @test eltype(d0) ≡ RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{0, Int, Int},
-            Union{Nothing, Simplex{1, Int, Int}},
-            Vector{ChainElement{Simplex{0, Int, Int}, Rational{Int}}}}
-        @test eltype(d1) ≡ RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{1, Int, Int},
-            Union{Nothing, Simplex{2, Int, Int}},
-            Vector{ChainElement{Simplex{1, Int, Int}, Rational{Int}}}}
-        @test eltype(d2) ≡ RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{2, Int, Int},
-            Union{Nothing, Simplex{3, Int, Int}},
-            Vector{ChainElement{Simplex{2, Int, Int}, Rational{Int}}}}
-        @test eltype(d3) ≡ RepresentativeInterval{
-            PersistenceInterval,
-            Simplex{3, Int, Int},
-            Union{Nothing, Simplex{4, Int, Int}},
-            Vector{ChainElement{Simplex{3, Int, Int}, Rational{Int}}}}
+        @test eltype(d0) isa DataType
+        @test eltype(d1) isa DataType
+        @test eltype(d2) isa DataType
+        @test eltype(d3) isa DataType
+        @test eltype(d3[1].representative) <: ChainElement
     end
     @testset "Infinite interval" begin
         _, d1 = ripserer(cycle; dim_max=1, reps=true, threshold=1, field_type=Rational{Int})
@@ -204,6 +174,29 @@ end
             @test all(isnothing, death_simplex.(infinite))
         end
     end
+end
+
+@testset "Diagram metadata" begin
+    filtration = Rips(cycle)
+    d0, d1, d2, d3 = ripserer(filtration; dim_max=3, reps=true, field_type=Rational{Int})
+    @test d0.dim == 0
+    @test d1.dim == 1
+    @test d2.dim == 2
+    @test d3.dim == 3
+    thresh = Float64(threshold(Rips(cycle)))
+    @test d0.threshold ≡ thresh
+    @test d1.threshold ≡ thresh
+    @test d2.threshold ≡ thresh
+    @test d3.threshold ≡ thresh
+    field_type=Rational{Int}
+    @test d0.field_type ≡ field_type
+    @test d1.field_type ≡ field_type
+    @test d2.field_type ≡ field_type
+    @test d3.field_type ≡ field_type
+    @test d0.filtration == filtration
+    @test d1.filtration == filtration
+    @test d2.filtration == filtration
+    @test d3.filtration == filtration
 end
 
 @testset "Zero-dimensional sublevel set persistence" begin
@@ -380,11 +373,14 @@ end
 Ripserer.n_vertices(::CustomFiltration) = 10
 Ripserer.simplex_type(::Type{CustomFiltration}, D) = Simplex{D, Int, Int}
 Ripserer.edges(::CustomFiltration) = Simplex{1}.(10:-1:1, 1)
-function Ripserer.postprocess_interval(::CustomFiltration, int::PersistenceInterval)
-    return PersistenceInterval(birth(int) + 1, death(int) + 1)
-end
-function Ripserer.postprocess_interval(::CustomFiltration, ::RepresentativeInterval)
-    return nothing
+function Ripserer.postprocess_diagram(::CustomFiltration, diagram)
+    result = PersistenceInterval[]
+    for int in diagram
+        if !hasproperty(int, :representative)
+            push!(result, PersistenceInterval(birth(int) + 1, death(int) + 1))
+        end
+    end
+    PersistenceDiagram(sort!(result); diagram.meta...)
 end
 
 @testset "Custom filtration" begin

--- a/test/zerodimensional.jl
+++ b/test/zerodimensional.jl
@@ -13,7 +13,7 @@ for arr in (1:10, CartesianIndices([1 2 3 4 5; 1 2 3 4 5]))
             for i in 1:10
                 @test find_root!(s, arr[i]) == arr[i]
                 @test find_leaves!(s, arr[i]) == [arr[i]]
-                @test birth(s, arr[i]) == i
+                @test birth(s, arr[i]) == (i, arr[i])
             end
             @test_throws BoundsError find_root!(s, arr[11])
         end


### PR DESCRIPTION
This non-breaking PR adds the following new features:
* All intervals now have a `birth_simplex` and a `death_simplex`.
* Resulting `PersistenceDiagram`s now have additional metadata attached, the `field_type` and the `filtration` used in computation.