### PR TITLE
Add optional apparent pair finding step

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.14.7"
+version = "0.14.8-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -279,6 +279,24 @@ computed. Defaults to `sort!`ing the diagram.
 """
 postprocess_diagram(::AbstractFiltration, diagram) = sort!(diagram)
 
+"""
+    find_apparent_pairs(::AbstractFiltration, columns, is_cohomology, progress)
+
+Find apparent pairs in filtration. Columns are the initial columns that are being reduced.
+Should return a tuple of:
+
+* A collection of columns that are left to reduce.
+* A collection of apparent pairs `(σ, τ)`. These will be insered into the reduced matrix so
+  that `matrix[τ] = [σ]`.
+
+!!! note
+    Mutating `columns` and returning it from this function is safe.
+
+!!! warning
+    This is still experimental.
+"""
+find_apparent_pairs(::AbstractFiltration, columns, _, _) = columns, ()
+
 # Vals everywhere so compiler computes this at compile time.
 @inline function interval_type(
     flt::AbstractFiltration, ::Val{dim}, ::Val{reps}, ::Type{F}

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -292,10 +292,13 @@ Should return a tuple of:
 !!! note
     Mutating `columns` and returning it from this function is safe.
 
+!!! note
+    This can only be applied to cohomology.
+
 !!! warning
     This is still experimental.
 """
-find_apparent_pairs(::AbstractFiltration, columns, _, _) = columns, ()
+find_apparent_pairs(::AbstractFiltration, columns, _) = columns, ()
 
 # Vals everywhere so compiler computes this at compile time.
 @inline function interval_type(

--- a/src/reductionmatrix.jl
+++ b/src/reductionmatrix.jl
@@ -99,7 +99,7 @@ function bulk_add!(matrix::ReducedMatrix{<:Any, E}, pairs) where E
     n_indices = length(matrix.indices)
     last_index = last(matrix.indices)
     resize!(matrix.indices, n_indices + n)
-    for (i, (σ, τ)) in enumerate(pairs)
+    @inbounds for (i, (σ, τ)) in enumerate(pairs)
         matrix.indices[n_indices + i] = last_index + i
         matrix.values[n_values + i] = E(σ, sign(τ))
         matrix.column_index[abs(τ)] = n_indices + i - 1

--- a/src/zerodimensional.jl
+++ b/src/zerodimensional.jl
@@ -150,7 +150,6 @@ function zeroth_intervals(
         progress && next!(progbar; showvalues=((:n_intervals, length(intervals)),))
     end
     reverse!(to_reduce)
-    progress && printstyled(stderr, "Assembled $(length(to_reduce)) edges.\n", color=:green)
 
     thresh = Float64(threshold(filtration))
     return (

--- a/test/filtrations/new-filtrations.jl
+++ b/test/filtrations/new-filtrations.jl
@@ -5,17 +5,9 @@ using Ripserer
 using StaticArrays
 using Test
 
+include(joinpath(@__DIR__, "test-datasets.jl"))
+
 # Julia 1.0 does not allow these to be defined inside @testset.
-struct NewRips <: Ripserer.AbstractRipsFiltration{Int, Float64} end
-Ripserer.dist(::NewRips) = Float64[i ≠ j for i in 1:10, j in 1:10]
-Ripserer.dist(::NewRips, i, j) = 1.0
-
-@testset "New rips filtration" begin
-    d0, d1 = ripserer(NewRips())
-    @test d0 == [fill((0.0, 1.0), 9); (0.0, Inf)]
-    @test d1 == []
-end
-
 struct NewFiltration <: Ripserer.AbstractFiltration{Int, Int} end
 
 function Ripserer.unsafe_simplex(
@@ -55,4 +47,57 @@ end
     d0, d1 = ripserer(NewFiltration(), reps=true)
     @test d0 == []
     @test d1 == []
+end
+
+# This test is mostly supposed to test that pre-finding apparent pairs with
+# `find_apparent_pairs` first works correctly. On the side, it also tests that rips
+# filtrations that only overload `dist` and `threshold` work fine.
+struct ApparentPairsRips{I, T} <: Ripserer.AbstractRipsFiltration{I, T}
+    rips::Rips{I, T}
+end
+
+ApparentPairsRips(data; kwargs...) = ApparentPairsRips(Rips(data; kwargs...))
+
+Ripserer.dist(rw::ApparentPairsRips) = Ripserer.dist(rw.rips)
+Ripserer.threshold(rw::ApparentPairsRips) = Ripserer.threshold(rw.rips)
+
+# This works fine but is slower than the original algorithm as apparent pairs are found in
+# `initialize_coboundary!` anyway. Doing this in parallel or on the GPU is an option,
+# however.  See https://arxiv.org/abs/2003.07989
+function Ripserer.find_apparent_pairs(rw::ApparentPairsRips, columns, is_cohomology, _)
+    if is_cohomology
+        S = eltype(columns)
+        C = Ripserer.simplex_type(rw, dim(S)+1)
+        cols_left = S[]
+        apparent = Tuple{S, C}[]
+        for σ in columns
+            τ = minimum(Ripserer.coboundary(rw, σ)) # This is broken if coboundary is empty.
+            σ′ = maximum(Ripserer.boundary(rw, τ))
+            if σ′ == σ
+                push!(apparent, (σ, τ))
+            else
+                push!(cols_left, σ)
+            end
+        end
+        return cols_left, apparent
+    else
+        return columns, ()
+    end
+end
+
+@testset "Rips with `find_apparent_pairs` overloaded." begin
+    for m in (2, 3, 5), t in (2, 1)
+        @testset "projective plane with modulus=$m, threshold=$t" begin
+            res_rips = ripserer(Rips(projective_plane; threshold=t); modulus=m)
+            res_appa = ripserer(ApparentPairsRips(projective_plane; threshold=t); modulus=m)
+            @test res_rips == res_appa
+        end
+    end
+    for m in (2, 3, 5), t in (8, 4)
+        @testset "cycle with modulus=$m, threshold=$t" begin
+            res_rips = ripserer(Rips(cycle; threshold=t); modulus=m, dim_max=3)
+            res_appa = ripserer(ApparentPairsRips(cycle; threshold=t); modulus=m, dim_max=3)
+            @test res_rips == res_appa
+        end
+    end
 end

--- a/test/filtrations/new-filtrations.jl
+++ b/test/filtrations/new-filtrations.jl
@@ -99,7 +99,7 @@ end
     end
 end
 
-# This test checks that apparent pairs can produce correct intervals. On the side, check
+# This test checks that apparent pairs can produce correct intervals. On the side, it checks
 # `AbstractCustomFiltration`s.
 struct ApparentPairsCustom <: Ripserer.AbstractCustomFiltration{Int, Int}
 end


### PR DESCRIPTION
Introduce function `find_apparent_pairs`. This makes it possible to add an apparent pair finding step before PH is computed. 
In principle, this could maybe be used to do something similar to Ripser++ (https://arxiv.org/pdf/2003.07989.pdf)