### PR TITLE
Filtration refactor

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.4
+          version: 1.5
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkTools BenchmarkCI@0.1"'
       - name: Run benchmarks

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ripserer"
 uuid = "aa79e827-bd0b-42a8-9f10-2b302677a641"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.14.8-DEV"
+version = "0.15.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/api/extensions.md
+++ b/docs/src/api/extensions.md
@@ -15,7 +15,7 @@ Ripserer.edges(::Ripserer.AbstractFiltration)
 ```
 
 ```@docs
-Ripserer.birth(::Ripserer.AbstractFiltration, ::Any)
+Ripserer.births(::Ripserer.AbstractFiltration)
 ```
 
 ```@docs
@@ -52,10 +52,6 @@ Ripserer.postprocess_diagram
 
 ```@docs
 Ripserer.AbstractRipsFiltration
-```
-
-```@docs
-Ripserer.dist
 ```
 
 ```@docs

--- a/docs/src/api/ripserer.md
+++ b/docs/src/api/ripserer.md
@@ -13,10 +13,6 @@ Rips
 ```
 
 ```@docs
-SparseRips
-```
-
-```@docs
 Cubical
 ```
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -25,8 +25,8 @@ hash `286d369`) and Cubical Ripser (commit hashes `6edb9c5` for 2D and `a063dac`
 
 In this experiment, we performed benchmarks with the datasets presented in the [Ripser
 article](https://arxiv.org/abs/1908.02518). We only used the datasets that we were able to
-run with less than 8GB memory. `ripserer_s` denotes `ripserer` run with
-[`SparseRips`](@ref). All datasets were parsed as `Float32` as that is what Ripser supports.
+run with less than 8GB memory. `ripserer_s` denotes `ripserer` run with `sparse=true`. All
+datasets were parsed as `Float32` as that is what Ripser supports.
 
 The timing results are in the table below. The ratio column shows the better ratio.
 

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -170,7 +170,7 @@ array of the same shape as the filtration's `vertices`.
 julia> flt = Rips([1 1 2; 1 0 1; 2 1 0]);
 
 julia> Ripserer.births(flt)
-3-element Array{Int64,1}:
+3-element view(::Array{Int64,1}, 1:4:9) with eltype Int64:
  1
  0
  0

--- a/src/abstractfiltration.jl
+++ b/src/abstractfiltration.jl
@@ -13,8 +13,7 @@ A filtration is used to find the edges in filtration and to create simplices. An
 * [`simplex(::AbstractFiltration, ::Val{dim}, vertices, sign)`](@ref)
 * [`unsafe_simplex(::AbstractFiltration, ::Val{dim}, vertices, sign)`](@ref)
 * [`unsafe_cofacet`](@ref)`(::AbstractFiltration, simplex, vertices, vertex, sign[, edges])`
-* [`birth(::AbstractFiltration, v)`](@ref)
-* [`birth(::AbstractFiltration)`](@ref)
+* [`births(::AbstractFiltration)`](@ref)
 * [`threshold(::AbstractFiltration)`](@ref)
 * [`columns_to_reduce(::AbstractFiltration, ::Any)`](@ref)
 * [`emergent_pairs(::AbstractFiltration)`](@ref)
@@ -160,21 +159,17 @@ Base.OneTo(3)
 vertices(flt::AbstractFiltration) = Base.OneTo(nv(flt))
 
 """
-    birth(::AbstractFiltration, v)
-    birth(::AbstractFiltration)
+    births(::AbstractFiltration)
 
-Get the birth time of vertex `v` in filtration. Defaults to 0. When `v` is not given, return
-births in an array of same size as [`vertices(::AbstractFiltration)`](@ref).
+Get the birth times of vertices in filtration. Defaults to all births being 0. Must return
+array of the same shape as the filtration's `vertices`.
 
 # Examples
 
 ```jldoctest
 julia> flt = Rips([1 1 2; 1 0 1; 2 1 0]);
 
-julia> birth(flt, 1)
-1
-
-julia> birth(flt)
+julia> Ripserer.births(flt)
 3-element Array{Int64,1}:
  1
  0
@@ -182,8 +177,7 @@ julia> birth(flt)
 
 ```
 """
-birth(::AbstractFiltration{<:Any, T}, _) where T = zero(T)
-birth(flt::AbstractFiltration{<:Any, T}) where T = zeros(T, size(vertices(flt)))
+births(flt::AbstractFiltration{<:Any, T}) where T = zeros(T, size(vertices(flt)))
 
 """
     threshold(::AbstractFiltration)
@@ -218,11 +212,11 @@ julia> Ripserer.adjacency_matrix(Rips([0 2 1; 2 0 1; 1 1 0]))
  2  0  1
  1  1  0
 
-julia> Ripserer.adjacency_matrix(SparseRips([0 0 1; 0 0 1; 1 1 0]))
+julia> Ripserer.adjacency_matrix(Rips([0 10 2; 10 0 1; 2 1 0]; sparse=true))
 3×3 SparseArrays.SparseMatrixCSC{Int64,Int64} with 4 stored entries:
-  [3, 1]  =  1
+  [3, 1]  =  2
   [3, 2]  =  1
-  [1, 3]  =  1
+  [1, 3]  =  2
   [2, 3]  =  1
 
 julia> Ripserer.adjacency_matrix(Custom([(2, 1) => 1, (5, 1) => 2, (3, 4) => 3]))

--- a/src/filtrations/alpha.jl
+++ b/src/filtrations/alpha.jl
@@ -170,7 +170,7 @@ julia> alpha = Alpha(data)
 Alpha{Int64, Float64}(nv=100)
 
 julia> rips = Rips(data)
-Rips{Int64, Float64}(nv=100)
+Rips{Int64, Float64}(nv=100, sparse=false)
 
 julia> length(Ripserer.edges(alpha))
 197

--- a/src/filtrations/cubical.jl
+++ b/src/filtrations/cubical.jl
@@ -151,8 +151,7 @@ threshold(cf::Cubical) = cf.threshold
 simplex_type(::Type{<:Cubical{K, T}}, D) where {K, T} = Cube{D, T, K}
 
 # when working with vertices, we don't cubemap them.
-birth(cf::Cubical, i) = cf.data[i]
-birth(cf::Cubical) = cf.data
+births(cf::Cubical) = cf.data
 vertices(cf::Cubical) = CartesianIndices(cf.data)
 
 function edges(cf::Cubical{K}) where K

--- a/src/filtrations/custom.jl
+++ b/src/filtrations/custom.jl
@@ -48,8 +48,7 @@ end
 
 dim(cf::AbstractCustomFiltration) = length(simplex_dicts(cf)) - 1
 simplex_type(::Type{<:AbstractCustomFiltration{I, T}}, D) where {I, T} = Simplex{D, T, I}
-birth(cf::AbstractCustomFiltration, v) = simplex_dicts(cf)[1][v]
-birth(cf::AbstractCustomFiltration) = [simplex_dicts(cf)[1][i] for i in 1:nv(cf)]
+births(cf::AbstractCustomFiltration) = [simplex_dicts(cf)[1][i] for i in 1:nv(cf)]
 edges(cf::AbstractCustomFiltration) = cf[Val(1)]
 columns_to_reduce(cf::AbstractCustomFiltration, prev) = cf[Val(dim(eltype(prev)) + 1)]
 nv(cf::AbstractCustomFiltration) = size(adjacency_matrix(cf), 1)

--- a/src/filtrations/rips.jl
+++ b/src/filtrations/rips.jl
@@ -1,15 +1,16 @@
 """
     AbstractRipsFiltration{I<:Signed, T} <: AbstractFiltration{I, T}
 
-An abstract Vietoris-Rips filtration. Its subtypes can only overload [`dist`](@ref) and get
-default implementations for the rest of the filtration interface.
+An abstract Vietoris-Rips filtration. Its subtypes can only overload
+[`adjacency_matrix`](@ref) and get default implementations for the rest of the filtration
+interface.
 
 # Example
 
 ```jldoctest
 julia> struct MyRips <: Ripserer.AbstractRipsFiltration{Int, Float16} end
 
-julia> Ripserer.dist(::MyRips) = [0 1 1; 1 0 1; 1 1 0]
+julia> Ripserer.adjacency_matrix(::MyRips) = [0 1 1; 1 0 1; 1 1 0]
 
 julia> ripserer(MyRips())
 2-element Array{PersistenceDiagrams.PersistenceDiagram,1}:
@@ -20,38 +21,12 @@ julia> ripserer(MyRips())
 """
 abstract type AbstractRipsFiltration{I<:Signed, T} <: AbstractFiltration{I, T} end
 
-"""
-    dist(::AbstractRipsFiltration, u, v)
-    dist(::AbstractRipsFiltration)
-
-Return the distance between vertices `u` and `v`. If the distance is somehow invalid, it may
-return `missing` instead. If `u` and `v` are not given, return the distance matrix.
-
-# Examples
-
-```jldoctest
-julia> flt = Rips([1 1 2; 1 0 1; 2 1 0]);
-
-julia> Ripserer.dist(flt, 1, 3)
-2
-
-julia> Ripserer.dist(flt)
-3×3 Array{Int64,2}:
- 1  1  2
- 1  0  1
- 2  1  0
-
-```
-"""
-dist(rips::AbstractRipsFiltration, i, j) = dist(rips)[i, j]
-
-nv(rips::AbstractRipsFiltration) = size(dist(rips), 1)
-birth(rips::AbstractRipsFiltration) = diag(dist(rips))
+nv(rips::AbstractRipsFiltration) = size(adjacency_matrix(rips), 1)
+births(rips::AbstractRipsFiltration) = diag(adjacency_matrix(rips))
 simplex_type(::Type{<:AbstractRipsFiltration{I, T}}, D) where {I, T} = Simplex{D, T, I}
-adjacency_matrix(rips::AbstractRipsFiltration) = dist(rips)
 
 function edges(rips::AbstractRipsFiltration)
-    if issparse(dist(rips))
+    if issparse(adjacency_matrix(rips))
         _sparse_edges(rips)
     else
         _full_edges(rips)
@@ -60,7 +35,7 @@ end
 
 function _full_edges(rips::AbstractRipsFiltration)
     result = edge_type(rips)[]
-    @inbounds for u in 1:size(dist(rips), 1), v in u+1:size(dist(rips), 1)
+    @inbounds for u in 1:nv(rips), v in u+1:nv(rips)
         sx = unsafe_simplex(rips, Val(1), (v, u), 1)
         !isnothing(sx) && push!(result, sx)
     end
@@ -68,11 +43,11 @@ function _full_edges(rips::AbstractRipsFiltration)
 end
 
 function _sparse_edges(rips::AbstractRipsFiltration)
+    adj = adjacency_matrix(rips)
     result = edge_type(rips)[]
-    rows = rowvals(rips.dist)
-    vals = nonzeros(rips.dist)
-    for u in 1:size(rips.dist, 1)
-        for i in nzrange(dist(rips), u)
+    rows = rowvals(adj)
+    for u in 1:nv(rips)
+        for i in nzrange(adj, u)
             v = rows[i]
             if v > u
                 sx = unsafe_simplex(rips, Val(1), (v, u), 1)
@@ -81,6 +56,73 @@ function _sparse_edges(rips::AbstractRipsFiltration)
         end
     end
     return result
+end
+
+@inline @propagate_inbounds function unsafe_simplex(
+    ::Type{S}, rips::AbstractRipsFiltration{I, T}, vertices, sign
+) where {I, T, S<:Simplex}
+    if dim(S) == 0
+        return S(I(sign) * vertices[1], births(rips)[vertices[1]])
+    else
+        adj = adjacency_matrix(rips)
+        n = length(vertices)
+        diameter = typemin(T)
+        for i in 1:n, j in i+1:n
+            d = adj[vertices[j], vertices[i]]
+            (iszero(d) || d > threshold(rips)) && return nothing
+            diameter = ifelse(d > diameter, d, diameter)
+        end
+        return S(I(sign) * index(vertices), diameter)
+    end
+end
+
+@inline @propagate_inbounds function unsafe_cofacet(
+    ::Type{S},
+    rips::AbstractRipsFiltration{I, T},
+    simplex,
+    cofacet_vertices,
+    new_vertex,
+    sign,
+) where {I, T, S<:Simplex}
+    diameter = birth(simplex)
+    adj = adjacency_matrix(rips)
+    for v in cofacet_vertices
+        v == new_vertex && continue
+        # Even though this looks like a tight loop, v changes way more often than us, so
+        # this is the faster order of indexing by new_vertex and v.
+        d = adj[new_vertex, v]
+        (iszero(d) || d > threshold(rips)) && return nothing
+        diameter = ifelse(d > diameter, d, diameter)
+    end
+    return S(I(sign) * index(cofacet_vertices), diameter)
+end
+
+# This definition is used in SparseCoboundary
+@inline @propagate_inbounds function unsafe_cofacet(
+    ::Type{S},
+    rips::AbstractRipsFiltration{I},
+    simplex,
+    cofacet_vertices,
+    _,
+    sign,
+    new_edges,
+) where {I, S<:Simplex}
+    diameter = birth(simplex)
+    for e in new_edges
+        e > threshold(rips) && return nothing
+        diameter = ifelse(e > diameter, e, diameter)
+    end
+    return S(I(sign) * index(cofacet_vertices), diameter)
+end
+
+function coboundary(
+    rips::AbstractRipsFiltration, sx::AbstractSimplex, ::Val{A}=Val(true)
+) where A
+    if adjacency_matrix(rips) isa SparseMatrixCSC
+        return SparseCoboundary{A}(rips, sx)
+    else
+        return Coboundary{A}(rips, sx)
+    end
 end
 
 """
@@ -119,8 +161,11 @@ end
 
 Calculate the radius of the space. This is used for default `thresholds`.
 """
-function radius(dists::AbstractMatrix{T}) where T
+function radius(dists::AbstractMatrix)
     return minimum(maximum(abs, dists[:, i]) for i in 1:size(dists, 1))
+end
+function radius(dists::SparseMatrixCSC)
+    return maximum(dists)
 end
 function radius(points, metric=Euclidean())
     radius = Inf
@@ -135,77 +180,44 @@ function radius(points, metric=Euclidean())
     return radius
 end
 
-@inline @propagate_inbounds function unsafe_simplex(
-    ::Type{S}, rips::AbstractRipsFiltration{I, T}, vertices, sign
-) where {I, T, S<:Simplex}
-    if dim(S) == 0
-        return S(I(sign) * vertices[1], birth(rips, vertices[1]))
-    else
-        n = length(vertices)
-        diameter = typemin(T)
-        for i in 1:n, j in i+1:n
-            d = dist(rips, vertices[j], vertices[i])
-            if ismissing(d) || d > threshold(rips)
-                return nothing
-            else
-                _d::T = d
-                diameter = ifelse(_d > diameter, _d, diameter)
-            end
-        end
-        return S(I(sign) * index(vertices), diameter)
-    end
-end
-
-@inline @propagate_inbounds function unsafe_cofacet(
-    ::Type{S},
-    rips::AbstractRipsFiltration{I, T},
-    simplex,
-    cofacet_vertices,
-    new_vertex,
-    sign,
-) where {I, T, S<:Simplex}
-    diameter = birth(simplex)
-    for v in cofacet_vertices
-        v == new_vertex && continue
-        # Even though this looks like a tight loop, v changes way more often than us, so
-        # this is the faster order of indexing by new_vertex and v.
-        d = dist(rips, new_vertex, v)
-        if ismissing(d) || d > threshold(rips)
-            return nothing
-        else
-            _d::T = d
-            diameter = ifelse(_d > diameter, _d, diameter)
+function _check_distance_matrix(dist::SparseMatrixCSC)
+    n = LinearAlgebra.checksquare(dist)
+    vals = nonzeros(dist)
+    rows = rowvals(dist)
+    for i in 1:n
+        vertex_birth = dist[i, i]
+        for j in nzrange(dist, i)
+            i == rows[j] && continue
+            edge_birth = vals[j]
+            iszero(edge_birth) && throw(ArgumentError(
+                "zero edges in input matrix"
+            ))
+            edge_birth < vertex_birth && throw(ArgumentError(
+                "edges with birth value lower than vertex births in input matrix"
+            ))
+            edge_birth ≠ dist[i, rows[j]] && throw(ArgumentError(
+                "input matrix not symmetric"
+            ))
         end
     end
-    return S(I(sign) * index(cofacet_vertices), diameter)
 end
 
-# This definition is used in SparseCoboundary
-@inline @propagate_inbounds function unsafe_cofacet(
-    ::Type{S},
-    rips::AbstractRipsFiltration{I},
-    sx,
-    cofacet_vertices,
-    _,
-    sign,
-    new_edges,
-) where {I, S<:Simplex}
-    new_diam = birth(sx)
-    for e in new_edges
-        e > threshold(rips) && return nothing
-        new_diam = ifelse(e > new_diam, e, new_diam)
-    end
-    new_index = index(cofacet_vertices)
-    return S(I(sign) * new_index, new_diam)
-end
-
-function coboundary(
-    rips::AbstractRipsFiltration, sx::AbstractSimplex, ::Val{A}=Val(true)
-) where A
-    if dist(rips) isa SparseMatrixCSC
-        return SparseCoboundary{A}(rips, sx)
-    else
-        return Coboundary{A}(rips, sx)
+function _check_distance_matrix(dist)
+    n = LinearAlgebra.checksquare(dist)
+    for i in 1:n
+        for j in i+1:n
+            vertex_birth = max(dist[j, j], dist[i, i])
+            edge_birth = dist[j, i]
+            iszero(edge_birth) && throw(ArgumentError(
+                "zero edges in input matrix"
+            ))
+            edge_birth < vertex_birth && throw(ArgumentError(
+                "edges with birth value lower than vertex births in input matrix"
+            ))
+            edge_birth ≠ dist[i, j] && throw(ArgumentError(
+                "input matrix not symmetric"
+            ))
+        end
     end
 end
 
@@ -213,10 +225,15 @@ end
     Rips{I, T} <: AbstractRipsFiltration{I, T}
 
 This type represents a filtration of Vietoris-Rips complexes.
-Diagonal items are treated as vertex birth times.
+
+Diagonal items in the input matrix are treated as vertex birth times.
+
+Zero values are not allowed due to how sparse matrices work in Julia. If you need zero birth
+times, try offseting all values by a constant.
 
 Threshold defaults to the radius of the input space. When using low `threshold`s, consider
-using [`SparseRips`](@ref) instead. It will give the same result, but may be much faster.
+using the `sparse=true` keyword argument. It will give the same result, but may be much
+faster.
 
 # Constructors
 
@@ -247,103 +264,40 @@ julia> ripserer(Rips(data, metric=Cityblock()))[2]
 ```
 """
 struct Rips{I, T, A<:AbstractMatrix{T}} <: AbstractRipsFiltration{I, T}
-    dist::A
+    adj::A
     threshold::T
 end
 
 function Rips{I}(
-    dist::AbstractMatrix{T}; threshold=nothing
+    dists::AbstractMatrix{T}; threshold=nothing, sparse=false,
 ) where {I, T}
-    issymmetric(dist) ||
-        throw(ArgumentError("`dist` must be symmetric"))
-    !issparse(dist) ||
-        throw(ArgumentError("`dist` is sparse. Use `SparseRips` instead"))
-    thresh = isnothing(threshold) ? radius(dist) : T(threshold)
-    return Rips{I, T, typeof(dist)}(dist, thresh)
+    _check_distance_matrix(dists)
+    thresh = isnothing(threshold) ? radius(dists) : T(threshold)
+    if sparse
+        adj = SparseArrays.sparse(dists)
+    else
+        adj = dists
+    end
+    if issparse(adj)
+        adj isa SparseMatrixCSC || throw(ArgumentError(
+            "only SparseMatrixCSC sparse matrices supported"
+        ))
+        SparseArrays.fkeep!(adj, (_, _, v) -> v ≤ thresh)
+    end
+    return Rips{I, T, typeof(adj)}(adj, thresh)
 end
 function Rips{I}(points::AbstractVector; metric=Euclidean(), kwargs...) where I
     return Rips{I}(distances(metric, points); kwargs...)
 end
-function Rips(dist; kwargs...)
-    return Rips{Int}(dist; kwargs...)
+function Rips(dist_or_points; kwargs...)
+    return Rips{Int}(dist_or_points; kwargs...)
 end
 
-@propagate_inbounds function dist(rips::Rips{<:Any, T}, i, j) where T
-    return rips.dist[i, j]
+function Base.show(io::IO, rips::Rips{I, T}) where {I, T}
+    print(io, "Rips{$I, $T}(nv=$(nv(rips)), sparse=$(issparse(rips.adj)))")
 end
-dist(rips::Rips) = rips.dist
 
 threshold(rips::Rips) = rips.threshold
-birth(rips::Rips, i) = rips.dist[i, i]
+adjacency_matrix(rips::Rips) = rips.adj
 
-# sparse rips filtration ================================================================= #
-"""
-    SparseRips{I, T} <: AbstractRipsFiltration{T, Simplex}
-
-This type represents a sparse filtration of Vietoris-Rips complexes.
-The distance matrix will be converted to a sparse matrix with all values greater than
-threshold deleted. Off-diagonal zeros in the matrix are treated as `missing`. Diagonal items
-are treated as vertex birth times.
-
-Use this filtration type with low `threshold`s.
-
-# Constructor
-
-* `SparseRips{I}(distance_matrix; threshold=nothing)`
-* `SparseRips(distance_matrix; threshold=nothing)`: `I` sets the integer size used to
-  represent simplices.
-
-# Examples
-
-```jldoctest
-julia> data = [(sin(t), cos(t)) for t in range(0, 2π, length=101)][1:end-1];
-
-julia> ripserer(SparseRips(data))
-2-element Array{PersistenceDiagrams.PersistenceDiagram,1}:
- 100-element 0-dimensional PersistenceDiagram
- 1-element 1-dimensional PersistenceDiagram
-
-julia> ripserer(SparseRips(data, threshold=1.7))[2]
-1-element 1-dimensional PersistenceDiagram:
- [0.0628, ∞)
-
-julia> using Distances
-
-julia> ripserer(SparseRips(data, metric=Cityblock()))[2]
-1-element 1-dimensional PersistenceDiagram:
- [0.0888, 2.0)
-
-```
-"""
-struct SparseRips{I, T} <: AbstractRipsFiltration{I, T}
-    dist::SparseMatrixCSC{T, Int}
-    threshold::T
-end
-
-function SparseRips{I}(
-    dist::AbstractMatrix{T}; threshold=nothing
-) where {I, T}
-    issymmetric(dist) || throw(ArgumentError("`dist` must be symmetric"))
-    if isnothing(threshold)
-        threshold = issparse(dist) ? maximum(dist) : radius(dist)
-    end
-    dists = SparseArrays.fkeep!(SparseMatrixCSC(dist), (_, _, v) -> v ≤ threshold)
-
-    return SparseRips{I, T}(dists, threshold)
-end
-function SparseRips(dist; kwargs...)
-    return SparseRips{Int}(dist; kwargs...)
-end
-function SparseRips{I}(points::AbstractVector; metric=Euclidean(), kwargs...) where I
-    return SparseRips{I}(distances(metric, points); kwargs...)
-end
-
-@propagate_inbounds function dist(rips::SparseRips{<:Any, T}, i, j) where T
-    res = rips.dist[i, j]
-    return ifelse(i == j, res, ifelse(iszero(res), missing, res))
-end
-dist(rips::SparseRips) = rips.dist
-
-threshold(rips::SparseRips) = rips.threshold
-birth(rips::SparseRips, i) = rips.dist[i, i]
-simplex_type(::SparseRips{I, T}, dim) where {I, T} = Simplex{dim, T, I}
+@deprecate SparseRips(args...; kwargs...) Rips(args...; sparse=true, kwargs...)

--- a/src/filtrations/rips.jl
+++ b/src/filtrations/rips.jl
@@ -22,7 +22,12 @@ julia> ripserer(MyRips())
 abstract type AbstractRipsFiltration{I<:Signed, T} <: AbstractFiltration{I, T} end
 
 nv(rips::AbstractRipsFiltration) = size(adjacency_matrix(rips), 1)
-births(rips::AbstractRipsFiltration) = diag(adjacency_matrix(rips))
+
+function births(rips::AbstractRipsFiltration)
+    adj = adjacency_matrix(rips)
+    return view(adj, diagind(adj))
+end
+
 simplex_type(::Type{<:AbstractRipsFiltration{I, T}}, D) where {I, T} = Simplex{D, T, I}
 
 function edges(rips::AbstractRipsFiltration)

--- a/src/filtrations/rips.jl
+++ b/src/filtrations/rips.jl
@@ -281,7 +281,7 @@ function Rips{I}(
     if sparse
         adj = SparseArrays.sparse(dists)
     else
-        adj = dists
+        adj = copy(dists)
     end
     if issparse(adj)
         adj isa SparseMatrixCSC || throw(ArgumentError(

--- a/src/main.jl
+++ b/src/main.jl
@@ -20,7 +20,7 @@ If using points, `points` must be an array of `isbits` types, such as `NTuple`s 
   parameter is only applicable when using distance matrices or points as input. When using
   filtrations, threshold must be passed to the filtration constructor. Defaults to the
   radius of the input space. When using low thresholds with points or distance matrices,
-  consider using [`SparseRips`](@ref).
+  consider using `sparse=true`.
 * `cutoff`: only keep intervals with `persistence(interval) > cutoff`. Defaults to `0`.
 * `reps`: if `true`, return representative cocycles along with persistence intervals.
   Defaults to `false`.
@@ -36,13 +36,10 @@ If using points, `points` must be an array of `isbits` types, such as `NTuple`s 
 function ripserer(
     dists::AbstractMatrix;
     threshold=nothing,
+    sparse=false,
     kwargs...,
 )
-    if issparse(dists)
-        filtration = SparseRips(dists; threshold=threshold)
-    else
-        filtration = Rips(dists; threshold=threshold)
-    end
+    filtration = Rips(dists; threshold=threshold, sparse=sparse)
     return ripserer(filtration; kwargs...)
 end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -61,11 +61,21 @@ function ripserer(
     cohomology=true,
 )
     index_overflow_check(filtration, field_type, dim_max)
-    return if cohomology
-        _cohomology(filtration, cutoff, progress, field_type, Val(dim_max), Val(reps))
+    start_time = time_ns()
+    if cohomology
+        result = _cohomology(
+            filtration, cutoff, progress, field_type, Val(dim_max), Val(reps)
+        )
     else
-        _homology(filtration, cutoff, progress, field_type, Val(dim_max), Val(reps))
+        result = _homology(
+            filtration, cutoff, progress, field_type, Val(dim_max), Val(reps)
+        )
     end
+    if progress
+        elapsed = round((time_ns() - start_time) / 1e9, digits=3)
+        printstyled(stderr, "Done. Took $elapsed seconds.\n"; color=:green)
+    end
+    return result
 end
 
 function _cohomology(

--- a/src/zerodimensional.jl
+++ b/src/zerodimensional.jl
@@ -112,14 +112,14 @@ Only keep intervals with desired birth/death `cutoff`. Compute homology with coe
 function zeroth_intervals(
     filtration, cutoff, progress, ::Type{F}, ::Val{reps}
 ) where {F, reps}
-    V = vertex_type(filtration)
+    V = simplex_type(filtration, 0)
     CE = chain_element_type(V, F)
-    dset = DisjointSetsWithBirth(vertices(filtration), birth(filtration))
+    dset = DisjointSetsWithBirth(vertices(filtration), births(filtration))
 
     intervals = interval_type(filtration, Val(0), Val(reps), F)[]
 
-    to_skip = edge_type(filtration)[]
-    to_reduce = edge_type(filtration)[]
+    to_skip = simplex_type(filtration, 1)[]
+    to_reduce = simplex_type(filtration, 1)[]
     simplices = sort!(edges(filtration))
     if progress
         progbar = Progress(

--- a/test/filtrations/cubical.jl
+++ b/test/filtrations/cubical.jl
@@ -6,7 +6,7 @@ using Test
 using TupleTools
 
 using Ripserer: one_hot, cubemap, from_cubemap, to_cubemap, nv,
-    coboundary, boundary, edges,
+    coboundary, boundary, edges, births,
     chain_element_type, CubicalChainElement
 
 @testset "CubeMap" begin
@@ -161,7 +161,7 @@ end
         filtration = Cubical(data)
 
         @test nv(filtration) == length(data)
-        @test birth(filtration) == data
+        @test births(filtration) == data
         @test size(filtration.cubemap) == size(data) .* 2 .- 1
         @test vertices(filtration) == CartesianIndices(data)
     end

--- a/test/filtrations/custom.jl
+++ b/test/filtrations/custom.jl
@@ -3,7 +3,7 @@ using SparseArrays
 using Test
 using TupleTools
 
-using Ripserer: adjacency_matrix
+using Ripserer: adjacency_matrix, births
 
 
 @testset "Custom filtration 1" begin
@@ -63,12 +63,12 @@ end
          for i in 1:4 for j in i+1:4 for k in j+1:4];
     ])
     @test simplex(cf, Val(3), (4, 3, 2, 1)) == nothing
-    @test all(birth(cf, i) == 0 for i in 1:4)
+    @test births(cf) == zeros(4)
 
     @test ripserer(dist) == ripserer(cf)
 end
 
-@testset "Custom filtration vs SparseRips" begin
+@testset "Custom filtration vs sparse Rips" begin
     spdist = sparse([
         0 1 0 0 0 1
         1 0 1 0 0 0
@@ -91,7 +91,7 @@ end
         (5, 6) => 1,
         (6, 1) => 1,
     ])
-    sprips = SparseRips(spdist)
+    sprips = Rips(spdist)
 
     @test adjacency_matrix(cf) == Bool.(spdist)
     @test threshold(cf) == 1

--- a/test/filtrations/new-filtrations.jl
+++ b/test/filtrations/new-filtrations.jl
@@ -53,7 +53,7 @@ end
 
 # This test is mostly supposed to test that pre-finding apparent pairs with
 # `find_apparent_pairs` first works correctly. On the side, it also tests that rips
-# filtrations that only overload `dist` and `threshold` work fine.
+# filtrations that only overload `adjacency_matrix` and `threshold` work fine.
 struct ApparentPairsRips{I, T, R<:Rips{I, T}} <: Ripserer.AbstractRipsFiltration{I, T}
     rips::R
     apparent::Ref{Int}
@@ -64,7 +64,7 @@ function ApparentPairsRips(data; kwargs...)
     return ApparentPairsRips(Rips(data; kwargs...), Ref(0), Ref(0))
 end
 
-Ripserer.dist(rw::ApparentPairsRips) = Ripserer.dist(rw.rips)
+Ripserer.adjacency_matrix(rw::ApparentPairsRips) = Ripserer.adjacency_matrix(rw.rips)
 Ripserer.threshold(rw::ApparentPairsRips) = Ripserer.threshold(rw.rips)
 
 # This works fine but is slower than the original algorithm (even if the pair finding code

--- a/test/filtrations/rips.jl
+++ b/test/filtrations/rips.jl
@@ -100,10 +100,22 @@ end
     @test maximum(adj) ≤ threshold(filtration)
 end
 
-struct SparseDummy <: AbstractSparseMatrix{Int, Int} end
-Base.size(::SparseDummy) = (10, 10)
-Base.getindex(::SparseDummy, i, j) = 1
-SparseArrays.issparse(::SparseDummy) = true
+@testset "Construction does not alter input" begin
+    dist = [0 9 1 2
+            9 0 3 4
+            1 3 0 4
+            2 4 4 0]
+    orig_dist = copy(dist)
+    Rips(dist, threshold=1)
+    @test dist == orig_dist
+    Rips(dist, threshold=1, sparse=true)
+    @test dist == orig_dist
+
+    dist = sparse(dist)
+    orig_dist = copy(dist)
+    Rips(dist, threshold=1)
+    @test dist == orig_dist
+end
 
 @testset "Errors" begin
     @testset "Non-square matrices throw an error" begin
@@ -117,9 +129,6 @@ SparseArrays.issparse(::SparseDummy) = true
     @testset "Edge births must be larger than vertex births" begin
         @test_throws ArgumentError Rips([1 1 1; 1 1 1; 1 1 2])
         @test_throws ArgumentError Rips([1 1 1; 1 2 1; 1 1 1]; sparse=true)
-    end
-    @testset "Only SparseMatrixCSC allowed for sparse filtrations" begin
-        @test_throws ArgumentError Rips(SparseDummy())
     end
 end
 


### PR DESCRIPTION
Simplify interfaces:
* drop `dist` in favor of `adjacency_matrix`
* drop both `birth(::AbstractFiltration)` methods in favor of `births`
* drop `SparseRips`, make `Rips` handle sparse matrices.

Other improvements:
* improve progress printing, fix bug with bad progress meter in column assembly.
* check `Rips` input matrix for correctness.