### PR TITLE
Minor fixes

### DIFF
--- a/src/filtrations/rips.jl
+++ b/src/filtrations/rips.jl
@@ -162,7 +162,7 @@ end
 
 """
     radius(dists)
-    radius(points[, metric=Euclidean()])
+    radius(points[, metric=Euclidean(1e-12)])
 
 Calculate the radius of the space. This is used for default `thresholds`.
 """
@@ -172,7 +172,7 @@ end
 function radius(dists::SparseMatrixCSC)
     return maximum(dists)
 end
-function radius(points, metric=Euclidean())
+function radius(points, metric=Euclidean(1e-12))
     radius = Inf
     for p in points
         p_max = 0.0
@@ -243,7 +243,7 @@ faster.
 # Constructors
 
 * `Rips(distance_matrix; threshold=nothing)`
-* `Rips(points; metric=Euclidean(), threshold=nothing)`
+* `Rips(points; metric=Euclidean(1e-12), threshold=nothing)`
 * `Rips{I}(args...)`: `I` sets the size of integer used to represent simplices.
 
 # Examples
@@ -291,8 +291,8 @@ function Rips{I}(
     end
     return Rips{I, T, typeof(adj)}(adj, thresh)
 end
-function Rips{I}(points::AbstractVector; metric=Euclidean(), kwargs...) where I
-    return Rips{I}(distances(metric, points); kwargs...)
+function Rips{I}(points::AbstractVector; metric=Euclidean(1e-12), kwargs...) where I
+    return Rips{I}(distances(metric, unique(points)); kwargs...)
 end
 function Rips(dist_or_points; kwargs...)
     return Rips{Int}(dist_or_points; kwargs...)

--- a/src/filtrations/rips.jl
+++ b/src/filtrations/rips.jl
@@ -150,11 +150,11 @@ function to_matrix(points)
 end
 
 """
-    distances(metric, points)
+    distances(points, metric=Euclidean(1e-12))
 
 Return distance matrix calculated from `points` with `metric`.
 """
-function distances(metric, points)
+function distances(points, metric=Euclidean(1e-12))
     points_mat = to_matrix(points)
     dists = pairwise(metric, points_mat, dims=2)
     return dists
@@ -207,7 +207,7 @@ function _check_distance_matrix(dist::SparseMatrixCSC)
     end
 end
 
-function _check_distance_matrix(dist)
+function _check_distance_matrix(dist::AbstractMatrix)
     n = LinearAlgebra.checksquare(dist)
     for i in 1:n
         for j in i+1:n
@@ -292,7 +292,11 @@ function Rips{I}(
     return Rips{I, T, typeof(adj)}(adj, thresh)
 end
 function Rips{I}(points::AbstractVector; metric=Euclidean(1e-12), kwargs...) where I
-    return Rips{I}(distances(metric, unique(points)); kwargs...)
+    if !allunique(points)
+        @warn "points not unique"
+        points = unique(points)
+    end
+    return Rips{I}(distances(points, metric); kwargs...)
 end
 function Rips(dist_or_points; kwargs...)
     return Rips{Int}(dist_or_points; kwargs...)

--- a/test/filtrations/rips.jl
+++ b/test/filtrations/rips.jl
@@ -222,9 +222,9 @@ end
         end
         @testset "Equal to Rips" begin
             for thresh in (nothing, 1, 0.5, 0.126)
-                data = rand_torus(100)
+                data = torus_points(100)
                 r_res = ripserer(data; threshold=thresh, dim_max=2)
-                s_res_1 = ripserer(Rips(data; threshold=thresh, sparse=true), dim_max=2)
+                s_res_1 = ripserer(data; threshold=thresh, sparse=true, dim_max=2)
 
                 # Add zeros to diagonal. Adding ones first actually changes the structure of
                 # the matrix.

--- a/test/filtrations/rips.jl
+++ b/test/filtrations/rips.jl
@@ -17,8 +17,8 @@ include("test-datasets.jl")
         [(0, 0), (0, 1), (1, 1), (1, 0)],
         [SVector(0, 0), SVector(0, 1), SVector(1, 1), SVector(1, 0)]
     )
-        @test distances(Euclidean(), points) ≈ [0 1 √2 1; 1 0 1 √2; √2 1 0 1; 1 √2 1 0]
-        @test distances(Cityblock(), points) == [0 1 2 1; 1 0 1 2; 2 1 0 1; 1 2 1 0]
+        @test distances(points) ≈ [0 1 √2 1; 1 0 1 √2; √2 1 0 1; 1 √2 1 0]
+        @test distances(points, Cityblock()) == [0 1 2 1; 1 0 1 2; 2 1 0 1; 1 2 1 0]
     end
 end
 
@@ -228,7 +228,7 @@ end
 
                 # Add zeros to diagonal. Adding ones first actually changes the structure of
                 # the matrix.
-                data2 = sparse(data)
+                data2 = sparse(Ripserer.distances(data))
                 for i in axes(data2, 1)
                     data2[i, i] = 1
                     data2[i, i] = 0

--- a/test/filtrations/rips.jl
+++ b/test/filtrations/rips.jl
@@ -117,6 +117,13 @@ end
     @test dist == orig_dist
 end
 
+@testset "warns with duplicate points" begin
+    pts = [(1, 0), (1, 1), (0, 1), (0, 0), (0, 0)]
+    @test @capture_err(Rips(pts)) ≠ ""
+    @test @capture_err(Rips(pts[1:4])) == ""
+    @test nv(@suppress Rips(pts)) == 4
+end
+
 @testset "Errors" begin
     @testset "Non-square matrices throw an error" begin
         @test_throws DimensionMismatch Rips(zeros(3, 2))


### PR DESCRIPTION
* Correctly handle `sparse=true` with point inputs.
* Use `Euclidean(1e-12)` by default to avoid rounding errors when computing distances.