### PR TITLE
Involuted hom gen fix

### DIFF
--- a/src/computation/cohomology.jl
+++ b/src/computation/cohomology.jl
@@ -277,6 +277,29 @@ function collect_cocycle!(matrix, column, pivot)
     end
 end
 
+function compute_infinite_representatives!(matrix::BoundaryMatrix{true}, birth_simplices)
+    representatives = Dict{eltype(birth_simplices),typeof(matrix.buffer)}()
+    isempty(birth_simplices) && return representatives
+
+    targets = Set(abs.(birth_simplices))
+    columns = matrix.columns_to_reduce
+    sort!(columns)
+    for column in columns
+        pivot = reduce_column!(matrix, column)
+        if isnothing(pivot) && column in targets
+            representative = copy(matrix.buffer)
+            push!(representative, column)
+            representatives[column] = clean!(representative, ordering(matrix))
+            delete!(targets, column)
+            isempty(targets) && break
+        end
+    end
+    if !isempty(targets)
+        error("could not reconstruct representatives for $(length(targets)) infinite bars")
+    end
+    return representatives
+end
+
 """
     interval(matrix, column, pivot, cutoff, reps)
 
@@ -301,6 +324,28 @@ function interval(matrix, column, pivot, cutoff, reps)
             rep = NamedTuple()
         end
         meta = (; birth_simplex=birth_simplex, death_simplex=death_simplex, rep...)
+        return PersistenceInterval(birth_time, death_time, meta)
+    else
+        return nothing
+    end
+end
+
+function infinite_interval(birth_simplex, cutoff)
+    birth_time = Float64(birth(birth_simplex))
+    death_time = Inf
+    if death_time - birth_time > cutoff
+        meta = (; birth_simplex, death_simplex=nothing)
+        return PersistenceInterval(birth_time, death_time, meta)
+    else
+        return nothing
+    end
+end
+
+function infinite_interval(birth_simplex, cutoff, representative)
+    birth_time = Float64(birth(birth_simplex))
+    death_time = Inf
+    if death_time - birth_time > cutoff
+        meta = (; birth_simplex, death_simplex=nothing, representative)
         return PersistenceInterval(birth_time, death_time, meta)
     else
         return nothing

--- a/src/computation/cohomology.jl
+++ b/src/computation/cohomology.jl
@@ -330,26 +330,16 @@ function interval(matrix, column, pivot, cutoff, reps)
     end
 end
 
-function infinite_interval(birth_simplex, cutoff)
+function infinite_interval(birth_simplex)
     birth_time = Float64(birth(birth_simplex))
-    death_time = Inf
-    if death_time - birth_time > cutoff
-        meta = (; birth_simplex, death_simplex=nothing)
-        return PersistenceInterval(birth_time, death_time, meta)
-    else
-        return nothing
-    end
+    meta = (; birth_simplex, death_simplex=nothing)
+    return PersistenceInterval(birth_time, Inf, meta)
 end
 
-function infinite_interval(birth_simplex, cutoff, representative)
+function infinite_interval(birth_simplex, representative)
     birth_time = Float64(birth(birth_simplex))
-    death_time = Inf
-    if death_time - birth_time > cutoff
-        meta = (; birth_simplex, death_simplex=nothing, representative)
-        return PersistenceInterval(birth_time, death_time, meta)
-    else
-        return nothing
-    end
+    meta = (; birth_simplex, death_simplex=nothing, representative)
+    return PersistenceInterval(birth_time, Inf, meta)
 end
 
 """

--- a/src/computation/ripserer.jl
+++ b/src/computation/ripserer.jl
@@ -243,12 +243,27 @@ function _ripserer(
         for dim in 1:dim_max
             columns, inf_births = compute_death_simplices!(comatrix, verbose, cutoff)
             matrix = BoundaryMatrix{implicit}(field, filtration, columns)
-            diagram = compute_intervals!(matrix, cutoff, verbose, _reps(reps, dim))
-            for birth_simplex in inf_births
-                push!(
-                    diagram.intervals,
-                    interval(comatrix, birth_simplex, nothing, 0, _reps(reps, dim)),
+            reps_in_dim = _reps(reps, dim)
+            diagram = compute_intervals!(matrix, cutoff, verbose, reps_in_dim)
+            inf_representatives = if reps_in_dim && !isempty(inf_births)
+                rep_matrix = BoundaryMatrix{true}(
+                    field,
+                    filtration,
+                    Iterators.flatten((comatrix.columns_to_reduce, comatrix.columns_to_skip)),
                 )
+                compute_infinite_representatives!(rep_matrix, inf_births)
+            else
+                nothing
+            end
+            for birth_simplex in inf_births
+                int = if isnothing(inf_representatives)
+                    infinite_interval(birth_simplex, cutoff)
+                else
+                    infinite_interval(
+                        birth_simplex, cutoff, inf_representatives[birth_simplex]
+                    )
+                end
+                !isnothing(int) && push!(diagram.intervals, int)
             end
             push!(result, diagram)
             if dim < dim_max

--- a/src/computation/ripserer.jl
+++ b/src/computation/ripserer.jl
@@ -246,10 +246,15 @@ function _ripserer(
             reps_in_dim = _reps(reps, dim)
             diagram = compute_intervals!(matrix, cutoff, verbose, reps_in_dim)
             inf_representatives = if reps_in_dim && !isempty(inf_births)
+                last_inf_birth = maximum(abs.(inf_births))
+                rep_columns = Iterators.filter(
+                    σ -> !isless(last_inf_birth, abs(σ)),
+                    Iterators.flatten((comatrix.columns_to_reduce, comatrix.columns_to_skip)),
+                )
                 rep_matrix = BoundaryMatrix{true}(
                     field,
                     filtration,
-                    Iterators.flatten((comatrix.columns_to_reduce, comatrix.columns_to_skip)),
+                    rep_columns,
                 )
                 compute_infinite_representatives!(rep_matrix, inf_births)
             else

--- a/src/computation/ripserer.jl
+++ b/src/computation/ripserer.jl
@@ -262,13 +262,11 @@ function _ripserer(
             end
             for birth_simplex in inf_births
                 int = if isnothing(inf_representatives)
-                    infinite_interval(birth_simplex, cutoff)
+                    infinite_interval(birth_simplex)
                 else
-                    infinite_interval(
-                        birth_simplex, cutoff, inf_representatives[birth_simplex]
-                    )
+                    infinite_interval(birth_simplex, inf_representatives[birth_simplex])
                 end
-                !isnothing(int) && push!(diagram.intervals, int)
+                push!(diagram.intervals, int)
             end
             push!(result, diagram)
             if dim < dim_max

--- a/test/filtrations/rips.jl
+++ b/test/filtrations/rips.jl
@@ -323,6 +323,22 @@ end
             @test vertices.(simplex.(representative(res_hom[2][1]))) ==
                 sort!(vcat([(i + 1, i) for i in 1:17], [(18, 1)]))
         end
+        @testset "Involuted infinite representative cycle" begin
+            flt = Rips(cycle; threshold=1)
+            _, d1 = ripserer(flt; alg=:involuted, reps=true, field=Rational{Int})
+            int = only(d1)
+            rep = representative(int)
+            boundary = Chain{Rational{Int},R.simplex_type(flt, 0)}()
+            for element in rep
+                for facet in R.boundary(flt, simplex(element))
+                    push!(boundary, (facet, coefficient(element)))
+                end
+            end
+
+            @test birth_simplex(int) in simplex.(rep)
+            @test rep isa Chain{Rational{Int},Simplex{1,Int,Int}}
+            @test isempty(R.clean!(boundary, Base.Order.Reverse))
+        end
         @testset "Infinite intervals" begin
             @test_broken ripserer(
                 Rips(cycle; threshold=2); alg=:homology, implicit=true


### PR DESCRIPTION
## Description

Previously, calling `alg=:involuted` with with `reps=true` would return cohomology representatives instead of homology representatives for infinite bars. Such bars can appear when working with a filtration threshold. This PR implements returning homology generators in this case.

## Implementation

In case of the `alg=:involuted`, `reps=true`, and infinite bars appearing, homology representatives are computed by reducing the relevant columns in the boundary matrix (which is generated up to the maximal relevant index).